### PR TITLE
Text options

### DIFF
--- a/examples/widgets/boxes.ts
+++ b/examples/widgets/boxes.ts
@@ -16,14 +16,21 @@ function hideLoad() {
 }
 
 function scrollText(text: Text) {
-  const KEY_DOWN = 40;
-  const KEY_UP = 38;
-
   document.addEventListener('keydown', (event) => {
-    if (event.keyCode === KEY_DOWN) {
-      text.scrollLines(1);
-    } else if (event.keyCode === KEY_UP) {
-      text.scrollLines(-1);
+    switch (event.key) {
+      case 'ArrowDown':
+        text.scrollLines(1);
+        break;
+      case 'ArrowUp':
+        text.scrollLines(-1);
+        break;
+      case 'PageUp':
+        text.scrollPages(-1);
+        break;
+      case 'PageDown':
+        text.scrollPages(1);
+        break;
+      default:
     }
   });
 }

--- a/examples/widgets/boxes.ts
+++ b/examples/widgets/boxes.ts
@@ -61,6 +61,7 @@ function run() {
   options.padding = { top: 0, bottom: 0, right: 0, left: 0};
   const box3 = terminal.attachWidget(Box, options) as Box;
   const textWidget = new Text(terminal, {
+    typewritterDelay: 50,
     text: ''
     //  |--------------------| // box size
       + 'This is a long '

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -21,6 +21,7 @@ export const defaultOptions: TerminalOptions = {
     bottom: undefined,
     left: undefined,
   },
+  avoidDoubleRendering: true,
 };
 
 export const defaultDebugOptions: DebugOptions = {

--- a/src/widgets/Box.ts
+++ b/src/widgets/Box.ts
@@ -161,7 +161,7 @@ export class Box extends Widget implements WidgetContainer {
       this.attachedWidget.setOptions(positionOptions);
     }
 
-    this.attachedWidget.render();
+    // this.attachedWidget.render();
 
     return this.attachedWidget;
   }

--- a/src/widgets/defaultOptions.ts
+++ b/src/widgets/defaultOptions.ts
@@ -35,4 +35,5 @@ export const boxDefaultOptions: BoxOptions = {
 export const textDefaultOptions: TextOptions = {
   tokenizer: true,
   fitPageEnd: false,
+  typewritterDelay: 0,
 };


### PR DESCRIPTION
* Added `typewritterDelay` option to the Text widget
* Added `avoidDoubleRendering` option to the Terminal
* Fixed rendering problem with decay characters when the rendering is **too fast**
