### PR TITLE
Select

### DIFF
--- a/examples/settings/select.ts
+++ b/examples/settings/select.ts
@@ -72,17 +72,17 @@ const pageSettingsLayout: SettingsLayout = {
               contents: [
                 new SettingButton({
                   text: '↓',
-                  callback: () => { selectWidget.next(); },
+                  callback: () => { selectWidget.focusNext(); },
                 }),
                 ' ',
                 new SettingButton({
                   text: '↑',
-                  callback: () => { selectWidget.prev(); },
+                  callback: () => { selectWidget.focusPrev(); },
                 }),
                 ' ',
                 new SettingButton({
                   text: 'Unselect',
-                  callback: () => { selectWidget.selectIndex(-1); },
+                  callback: () => { selectWidget.toggleIndex(-1); },
                 }),
               ],
             },

--- a/examples/settings/select.ts
+++ b/examples/settings/select.ts
@@ -112,6 +112,22 @@ const selectSettingsSection: SettingsSection = {
         },
       ],
     },
+    {
+      cols: [
+        {
+          title: 'Selected prefix',
+          contents: [
+            new SettingText({ name: 'selectedPrefix'}),
+          ],
+        },
+        {
+          title: 'Unselected prefix',
+          contents: [
+            new SettingText({ name: 'unselectedPrefix'}),
+          ],
+        },
+      ],
+    },
   ],
 };
 
@@ -236,6 +252,7 @@ function addSelectOption(): void {
   selectOptionsSettingRows.push(newRow);
   widgetSettingsLayout.sections[1].rows = [
     widgetSettingsLayout.sections[1].rows[0],
+    widgetSettingsLayout.sections[1].rows[1],
     ...selectOptionsSettingRows,
   ];
   widgetSettings.setSections(widgetSettingsLayout.sections);
@@ -349,7 +366,7 @@ function createPageSettings(): WidgetSettings {
 function preUpdateWidgeSettings(): boolean {
   updatePageSettings(pageSettings);
 
-  return true;
+  return false;
 }
 
 const widgetInitialSettings = {

--- a/examples/widgets/select.ts
+++ b/examples/widgets/select.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-magic-numbers */
 import { Terminal } from '../../src/Terminal';
 import { Box } from '../../src/widgets/Box';
-import { Select } from '../../src/widgets/Select';
+import { Select, SelectOptions } from '../../src/widgets/Select';
 
 import { load, LoadData } from '../util/load';
 
@@ -10,13 +10,19 @@ function enableInteraction(selects: Array<Select<number>>, terminal: Terminal, c
     if (event.key === 'ArrowUp') {
       selects.forEach((select) => {
         if (select.isFocused()) {
-          select.prev();
+          select.focusPrev();
         }
       });
     } else if (event.key === 'ArrowDown') {
       selects.forEach((select) => {
         if (select.isFocused()) {
-          select.next();
+          select.focusNext();
+        }
+      });
+    } else if (event.key === ' ') {
+      selects.forEach((select) => {
+        if (select.isFocused()) {
+          select.toggleIndex(select.getFocusedIndex());
         }
       });
     }
@@ -26,8 +32,7 @@ function enableInteraction(selects: Array<Select<number>>, terminal: Terminal, c
     const cell = terminal.getTilePosition(event.offsetX, event.offsetY);
     const widget = terminal.getLeafWidgetAt(cell.col, cell.line);
     if (widget instanceof Select) {
-      const option = widget.getOptionAt(cell.col, cell.line);
-      widget.selectOption(option);
+      widget.focusIndex(widget.getIndexAt(cell.col, cell.line));
     }
   });
 }
@@ -47,9 +52,10 @@ function run({ terminal, canvas }: LoadData): void {
 
   const s1 = terminal.attachWidget(Box, {
     ...boxOptions,
-    title: '[Select-A]',
+    title: '[S1] no loop',
     col: 1,
     line: 1,
+    loop: false,
   })
   .attachWidget<Select<number>>(Select, {
     options: [
@@ -57,40 +63,53 @@ function run({ terminal, canvas }: LoadData): void {
       { text: 'Option 2 (disabled)', value: 2, disabled: true },
       { text: 'Option 3', value: 3 },
     ],
-  });
+  } as SelectOptions<number>);
 
   const s2 = terminal.attachWidget(Box, {
     ...boxOptions,
-    title: '[Select-B]',
+    title: '[S2] custom styles',
     col: 1,
     line: 7,
   })
   .attachWidget<Select<number>>(Select, {
+    baseStyle: { fg: '#9999ff', bg: '#000000', prefix: '  ' },
+    baseFocusedStyle: { fg: '#ddddff', bg: '#000000', prefix: '> ' },
+    selectedStyle: { fg: '#9999ff', bg: '#000033', prefix: ' [', suffix: ']' },
+    selectedFocusedStyle: { fg: '#ddddff', bg: '#000033', prefix: '>[', suffix: ']' },
+    disabledStyle: { fg: '#000099', bg: '#0000ff', prefix: '  ' },
+    disabledSelectedStyle: { fg: '#000000', bg: '#000033', prefix: '> ' },
     options: [
       { text: 'Option 1', value: 1 },
       { text: 'Option 2 takes two lines', value: 2 },
-      { text: 'Option 3 is very very long and takes three lines', value: 3 },
+      { text: 'Option 3 is very very long and actually takes FOUR lines', value: 3 },
       { text: 'Option 4', value: 4 },
+      { text: 'Option 5 takes two lines', value: 5 },
     ],
-  });
+  } as SelectOptions<number>);
 
   const s3 = terminal.attachWidget(Box, {
     ...boxOptions,
-    title: '[Select-C]',
+    title: '[S3] multiple selection',
     col: 1,
     line: 13,
-    width: 30,
+    width: 27,
     height: 7,
   })
   .attachWidget<Select<number>>(Select, {
-    selectedIndex: 0,
-    selectedPrefix: '>',
+    multiple: true,
+    baseStyle: { prefix: '[ ] ' },
+    baseFocusedStyle: { prefix: '[ ] ' },
+    selectedStyle: { prefix: '[x] ' },
+    selectedFocusedStyle: { prefix: '[x] ' },
+    disabledStyle: { prefix: '[ ] ' },
+    disabledSelectedStyle: { prefix: '[x] ' },
     options: [
-      { text: 'Option 1 (default)', value: 1 },
+      { text: 'Option 1', value: 1 },
       { text: 'Option 2', value: 2 },
       { text: 'Option 3', value: 3 },
+      { text: 'Option 4', value: 4 },
     ],
-  });
+  } as SelectOptions<number>);
 
   enableInteraction([s1, s2, s3], terminal, canvas);
 }

--- a/examples/widgets/select.ts
+++ b/examples/widgets/select.ts
@@ -84,6 +84,7 @@ function run({ terminal, canvas }: LoadData): void {
   })
   .attachWidget<Select<number>>(Select, {
     selectedIndex: 0,
+    selectedPrefix: '>',
     options: [
       { text: 'Option 1 (default)', value: 1 },
       { text: 'Option 2', value: 2 },

--- a/src/widgets/Select.ts
+++ b/src/widgets/Select.ts
@@ -312,6 +312,42 @@ export class Select<T> extends Widget<SelectOptions<T>> {
   }
 
   /**
+   * Check if the option with the specified index is selected or not
+   *
+   * @param index index of the option to check
+   * @returns `true` if selected, `false` if not. `undefined` if the option is not found
+   */
+  public isIndexSelected(index: number): boolean {
+    const item = this.selectOptions[index];
+
+    return item ? item.selected : undefined;
+  }
+
+  /**
+   * Check if an option is selected or not
+   *
+   * @param option option to check
+   * @returns `true` if selected, `false` if not. `undefined` if the option is not found
+   */
+  public isOptionSelected(option: SelectOption<T>): boolean {
+    const index = this.getIndexFromOption(option);
+
+    return index === SELECT_INDEX_NONE ? undefined : this.selectOptions[index].selected;
+  }
+
+  /**
+   * Check if the option with the specified value is selected or not
+   *
+   * @param value value to check
+   * @returns `true` if selected, `false` if not. `undefined` if the option is not found
+   */
+  public isValueSelected(value: T): boolean {
+    const index = this.getIndexFromValue(value);
+
+    return index === SELECT_INDEX_NONE ? undefined : this.selectOptions[index].selected;
+  }
+
+  /**
    * Select the option with the specified index.
    * This will do nothing if the option is disabled or the index is invalid.
    * If `options.multiple` is `false`, then it will unselect any previously selected option.

--- a/src/widgets/Select.ts
+++ b/src/widgets/Select.ts
@@ -1,12 +1,14 @@
+import { isEmpty } from 'vanilla-type-check/isEmpty';
+
 import { CharStyle, Terminal } from '../Terminal';
 import { Widget, WidgetOptions } from '../Widget';
 import { WidgetContainer } from '../WidgetContainer';
 
-import { coalesce } from '../util/coalesce';
 import { deepAssign } from '../util/deepAssign';
 import { splitText, TokenizerFunction } from '../util/tokenizer';
 
-export const UNSELECTED_INDEX = -1;
+/** Value used for an option index when no option is selected or found */
+export const SELECT_INDEX_NONE = -1;
 
 export interface SelectOption<T> {
   /** Displayed text of the option */
@@ -17,51 +19,78 @@ export interface SelectOption<T> {
   disabled?: boolean;
 }
 
+export interface SelectOptionStyle extends CharStyle {
+  /** Text to add to the option at the beginning */
+  prefix?: string;
+  /** Text to add to the option at the end */
+  suffix?: string;
+}
+
 export interface SelectOptions<T> extends WidgetOptions {
   /** List of options, in order, to display. Editing this value (via `setOptions` will reset the selected one) */
   options: Array<SelectOption<T>>;
   /** If `true`, the first option will be highlighted after the last one, and viceversa */
   loop?: boolean;
-  /** Selected option index by default */
-  selectedIndex?: number;
+  /** When `false`, it will be only one option selected at most */
+  multiple?: boolean;
   /** If `true`, will unselect any selected option if try to select a non-existing one */
   allowUnselect?: boolean;
+
+  /** Character Style for base options */
+  baseStyle?: SelectOptionStyle;
+  /** Character Style for base options when focused */
+  baseFocusedStyle?: SelectOptionStyle;
+  /** Character Style for selected options */
+  selectedStyle?: SelectOptionStyle;
+  /** Character Style for selected options when focused */
+  selectedFocusedStyle?: SelectOptionStyle;
+  /** Character Style for disabled options */
+  disabledStyle?: SelectOptionStyle;
+  /** Character Style for disabled options when selected */
+  disabledSelectedStyle?: SelectOptionStyle;
+
   /**
    * How to split the text (for new lines, etc.)
    * A custom TokenizerFunction can be provided. Leave undefined to use the default one
    */
   tokenizer?: TokenizerFunction;
-  /** Character Style for base options */
-  base?: CharStyle;
-  /** Character Style for selected options */
-  selected?: CharStyle;
-  /** Character Style for disabled options */
-  disabled?: CharStyle;
-  /** Prefix to add to the selected options */
-  selectedPrefix?: string;
-  /** Prefix to add to the non selected options */
-  unselectedPrefix? : string;
+}
+
+type StyleStates = 'baseStyle'
+                 | 'baseFocusedStyle'
+                 | 'selectedStyle'
+                 | 'selectedFocusedStyle'
+                 | 'disabledStyle'
+                 | 'disabledSelectedStyle';
+
+interface InternalOption<T> {
+  /** Copy of the provided option */
+  option: SelectOption<T>;
+  /** Will be true if selected */
+  selected: boolean;
+  /** Preprocessed text to draw (one string per line) */
+  processedText: string[];
+  /** Line where this option should start (accumulated number of lines of the previous options) */
+  startLine: number;
+  /** Line where the next option should start (start + processedText.length) */
+  endLine: number;
 }
 
 /**
- * Display a list of selectable options
+ * Display a list of selectable options.
+ * The focused option is where the cursor is. It can be none or one at most.
+ * Selected options can be none, one or, if the `multiple` option is `true`, more than one at the same time
  */
 export class Select<T> extends Widget<SelectOptions<T>> {
   /** Default options for widget instances */
   public static defaultOptions: SelectOptions<any>; // tslint:disable-line:no-any
 
-  /** Currently selected option index */
-  private selectedIndex: number = UNSELECTED_INDEX;
+  /** Currently active option index */
+  private focusedIndex: number = SELECT_INDEX_NONE;
+  /** Lits of the options used internally */
+  private selectOptions: InternalOption<T>[];
   /** First line to draw (for scrolling) - note: one option can have more than one line */
   private firstLine: number = 0;
-  /** Processed options text */
-  private optionsText: string[][];
-  /** Processed indentation text */
-  private indentation: string;
-  /** Processed selected prefix text  */
-  private selectedPrefix: string;
-  /** Processed unselected prefix text */
-  private unselectedPrefix: string;
 
   constructor(terminal: Terminal, options: SelectOptions<T>, parent?: WidgetContainer) {
     super(
@@ -70,81 +99,204 @@ export class Select<T> extends Widget<SelectOptions<T>> {
       parent,
     );
 
-    let rendered = false;
-    if (this.options.selectedIndex >= 0) {
-      rendered = this.selectIndex(this.options.selectedIndex);
-    }
-    if (!rendered) {
-      this.render();
-    }
+    this.render();
   }
 
   /**
    * Render the widget in the associated terminal
    */
   public render(): void {
-    if (!this.optionsText) {
+    if (!this.selectOptions) {
       return;
     }
 
-    const lastLine = this.options.line + this.options.height;
+    const lastTerminalLine = this.options.line + this.options.height;
     let terminalLine = this.options.line; // line of the terminal to output the text
-    let option = 0; // option index
-    let optionLine = 0; // text line inside the current option
-    let line = 0; // accumulated internal option lines
+    let optionIndex = 0;
 
-    while (line < this.firstLine) {
-      line++;
-      optionLine++;
-      if (optionLine >= this.optionsText[option].length) {
-        option++;
-        optionLine = 0;
+    // skip first hidden lines
+    while (this.selectOptions[optionIndex].endLine <= this.firstLine) {
+      optionIndex++;
+    }
+    let skipLines = this.firstLine - this.selectOptions[optionIndex].startLine;
+
+    // write visible lines
+    while (optionIndex < this.selectOptions.length && terminalLine < lastTerminalLine) {
+      this.terminal.setTextStyle(this.getOptionStyle(optionIndex));
+      const text = this.getOptionText(optionIndex);
+
+      for (const textLine of text) {
+        if (terminalLine >= lastTerminalLine) {
+          break;
+        }
+        if (skipLines > 0) {
+          skipLines--;
+          continue;
+        }
+        this.terminal.setText(textLine, this.options.col, terminalLine);
+        terminalLine++;
       }
+
+      optionIndex++;
     }
 
-    this.terminal.setTextStyle(this.getAspectOptions(option));
-    const col = this.options.col;
-    const indentedCol = col + (this.indentation.length);
-    while (option < this.optionsText.length && terminalLine < lastLine) {
-      if (col !== indentedCol) {
-        if (optionLine > 0) {
-          this.terminal.setText(this.indentation, col, terminalLine);
-        } else if (this.selectedIndex === option) {
-          this.terminal.setText(this.selectedPrefix, col, terminalLine);
-        } else {
-          this.terminal.setText(this.unselectedPrefix, col, terminalLine);
-        }
-      }
-      this.terminal.setText(this.optionsText[option][optionLine], indentedCol, terminalLine);
-      terminalLine++;
-      optionLine++;
-      if (optionLine >= this.optionsText[option].length) {
-        option++;
-        optionLine = 0;
-        if (option < this.optionsText.length) {
-          this.terminal.setTextStyle(this.getAspectOptions(option));
-        }
-      }
-    }
+    // write blank lines if any
+    this.terminal.clear(this.options.col, terminalLine, this.options.width, lastTerminalLine - terminalLine);
   }
 
   /**
-   * Retrieve a reference to the currently selected option.
-   * Even if it's a reference, don't update it directly, but use `setOptions` to allow the widget to apply the changes
+   * Get the provided option from the specified index
    *
-   * @return Object specified in `options.options`.
+   * @param index index of the desired option
+   * @return Reference to a copy of the provided option
    */
-  public getSelectedOption(): SelectOption<T> {
-    return this.options.options[this.selectedIndex];
+  public getOptionFromIndex(index: number): SelectOption<T> {
+    const opt = this.selectOptions[index];
+
+    return opt ? opt.option : undefined;
   }
 
   /**
-   * Retrieve the index of the currently selected option
+   * Get the provided value from the specified index
+   *
+   * @param index index of the desired option
+   * @return Reference to a copy of the provided value
+   */
+  public getValueFromIndex(index: number): T {
+    const opt = this.selectOptions[index];
+
+    return opt ? opt.option.value : undefined;
+  }
+
+  /**
+   * Get the index of the desired option
+   *
+   * @param option option to search
+   * @return Index of the option in the select list or `INDEX_NONE` if not found
+   */
+  public getIndexFromOption(option: SelectOption<T>): number {
+    for (let i = 0; i < this.options.options.length; i++) {
+      if (this.options.options[i] === option) {
+        return i;
+      }
+    }
+
+    return SELECT_INDEX_NONE;
+  }
+
+  /**
+   * Get the index of the desired value
+   *
+   * @param value value to search
+   * @return Index of the option in the select list or `INDEX_NONE` if not found
+   */
+  public getIndexFromValue(value: T): number {
+    for (let i = 0; i < this.selectOptions.length; i++) {
+      if (this.selectOptions[i].option.value === value) {
+        return i;
+      }
+    }
+
+    return SELECT_INDEX_NONE;
+  }
+
+  /**
+   * Retrieve a list of indexes of the selected options.
+   *
+   * @return Indexes of the selected options
+   */
+  public getSelectedIndexes(): number[] {
+    const res: number[] = [];
+
+    this.selectOptions.forEach((option, i) => {
+      if (option.selected) {
+        res.push(i);
+      }
+    });
+
+    return res;
+  }
+
+  /**
+   * Retrieve a list of selected options.
+   * Even if this is a list of references to the given options, refrain of modifying them directly.
+   * Use `setOptions` instead.
+   *
+   * @return List of selected options
+   */
+  public getSelectedOptions(): SelectOption<T>[] {
+    return this.getSelectedIndexes().map((index) => this.selectOptions[index].option);
+  }
+
+  /**
+   * Retrieve a list of selected values.
+   *
+   * @return List of selected values
+   */
+  public getSelectedValues(): T[] {
+    return this.getSelectedIndexes().map((index) => this.selectOptions[index].option.value);
+  }
+
+  /**
+   * Retrieve the index of the focused option
    *
    * @return index of the selected option or `UNSELECTED_INDEX` if no one is selected
    */
-  public getSelectedIndex(): number {
-    return this.selectedIndex;
+  public getFocusedIndex(): number {
+    return this.focusedIndex;
+  }
+
+  /**
+   * Retrieve the focused option
+   *
+   * @return Reference to the given focused option, or `undefined` if nothing is selected
+   */
+  public getFocusedOption(): SelectOption<T> {
+    return this.getOptionFromIndex(this.focusedIndex);
+  }
+
+  /**
+   * Retrieve the value of the focused option
+   *
+   * @return Reference to the given focused option value, or `undefined` if nothing is selected
+   */
+  public getFocusedValue(): T {
+    return this.getValueFromIndex(this.focusedIndex);
+  }
+
+  /**
+   * Get the index of the option at the specified terminal position (absolute)
+   *
+   * @param column column of the terminal
+   * @param line line of the terminal
+   * @return index of the option or `INDEX_NONE` if not found
+   */
+  public getIndexAt(column: number, line: number): number {
+    const maxHeight = this.options.line + this.options.height;
+
+    if (column < this.options.col || column >= this.options.col + this.options.width
+      || line < this.options.line || line >= maxHeight) {
+      return SELECT_INDEX_NONE;
+    }
+
+    let terminalLine = this.options.line;
+    let optionLine = 0;
+    let optionIndex = 0;
+
+    while (optionIndex < this.selectOptions.length && terminalLine < maxHeight) {
+      if (terminalLine === line) {
+        return optionIndex;
+      }
+
+      terminalLine++;
+      optionLine++;
+      if (optionLine >= this.selectOptions[optionIndex].processedText.length) {
+        optionIndex++;
+        optionLine = 0;
+      }
+    }
+
+    return SELECT_INDEX_NONE;
   }
 
   /**
@@ -155,63 +307,107 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    * @return option or `undefined` if not found
    */
   public getOptionAt(column: number, line: number): SelectOption<T> {
-    if (column < this.options.col || column >= this.options.col + this.options.width) {
-      return;
-    }
+    return this.getOptionFromIndex(this.getIndexAt(column, line));
+  }
 
-    let terminalLine = this.options.line;
-    let optionLine = 0;
-    let option = 0;
-
-    while (option < this.optionsText.length) {
-      if (terminalLine === line) {
-        return this.options.options[option];
-      }
-
-      terminalLine++;
-      optionLine++;
-      if (optionLine >= this.optionsText[option].length) {
-        option++;
-        optionLine = 0;
-      }
-    }
-
-    return;
+  /**
+   * Get the value of the option at the specified terminal position (absolute)
+   *
+   * @param column column of the terminal
+   * @param line line of the terminal
+   * @return option value or `undefined` if not found
+   */
+  public getValueAt(column: number, line: number): T {
+    return this.getValueFromIndex(this.getIndexAt(column, line));
   }
 
   /**
    * Select the option with the specified index.
-   * This will do nothing if the option is disabled or the index not found.
+   * This will do nothing if the option is disabled or the index is invalid.
+   * If `options.multiple` is `false`, then it will unselect any previously selected option.
+   * The list won't focus the option and therefore, the scroll won't change.
+   *
+   * @param index New index to set as selected (starting on 0)
+   * @param selected If `true` the option will be set as selected.
+   *                 If `false`, the option will be set as unselected.
+   *                 If `undefined`, the option will be negated (selected -> unselected / unselected -> selected)
+   * @return `true` if the selected option has changed, `false` otherwise
+   */
+  public toggleIndex(index: number, selected?: boolean): boolean {
+    const item = this.selectOptions[index];
+    const newState = selected === undefined ? !item.selected : selected;
+    let change = item.selected !== newState;
+    item.selected = newState;
+
+    if (!this.options.multiple && item.selected) {
+      for (let i = 0; i < this.selectOptions.length; i++) {
+        const unselectedItem = this.selectOptions[i];
+        if (i !== index) {
+          change = change || unselectedItem.selected;
+          unselectedItem.selected = false;
+        }
+      }
+    }
+
+    if (change) {
+      this.render();
+      return true;
+    }
+
+    return true;
+  }
+
+  /**
+   * Select the first option with the specified.
+   * This will do nothing if all the options with that value are disabled
+   *
+   * @param option Value to search the option by
+   * @return `true` if the selected option has changed, `false` otherwise
+   */
+  public selectOption(option: SelectOption<T>): boolean {
+    return this.toggleIndex(this.getIndexFromOption(option));
+  }
+
+  /**
+   * Select the first option with the specified value.
+   * This will do nothing if all the options with that value are disabled
+   *
+   * @param value Value to search the option by
+   * @return `true` if the selected option has changed, `false` otherwise
+   */
+  public selectValue(value: T): boolean {
+    return this.toggleIndex(this.getIndexFromValue(value));
+  }
+
+  /**
+   * Focus the option with the specified index.
+   * This will do nothing if the option is already focused or the index is invalid.
+   * The list will scroll to show the focused option if needed.
    *
    * @param index New index to set as selected (starting on 0)
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public selectIndex(index: number): boolean {
-    const oldIndex = this.selectedIndex;
+  public focusIndex(index: number): boolean {
+    const oldIndex = this.focusedIndex;
+    const selectedOption = this.selectOptions[index];
 
-    if (this.optionsText[index]) {
-      if (!this.options.options[index].disabled && this.selectedIndex !== index) {
-        this.selectedIndex = index;
+    if (selectedOption) {
+      if (!selectedOption.option.disabled && this.focusedIndex !== index) {
+        this.focusedIndex = index;
 
         // manage the scroll to make the selected option appear in the screen
-        let startLine = 0;
-        for (let i = 0; i < index; i++) {
-          startLine += this.optionsText[i].length;
+        if (selectedOption.endLine > this.firstLine + this.options.height) {
+          this.firstLine = selectedOption.endLine - selectedOption.processedText.length + 1;
         }
-        const endLine = startLine + this.optionsText[index].length;
-
-        if (endLine >= this.firstLine + this.options.height) {
-          this.firstLine += endLine - this.firstLine - this.options.height;
-        }
-        if (startLine < this.firstLine) {
-          this.firstLine = startLine;
+        if (selectedOption.startLine < this.firstLine) {
+          this.firstLine = selectedOption.startLine;
         }
       }
-    } else if (this.options.allowUnselect && this.selectedIndex !== UNSELECTED_INDEX) {
-      this.selectedIndex = UNSELECTED_INDEX;
+    } else if (this.options.allowUnselect) {
+      this.focusedIndex = SELECT_INDEX_NONE;
     }
 
-    if (oldIndex !== this.selectedIndex) {
+    if (oldIndex !== this.focusedIndex) {
       this.render();
 
       return true;
@@ -221,59 +417,36 @@ export class Select<T> extends Widget<SelectOptions<T>> {
   }
 
   /**
-   * Select the first option with the specified value.
-   * This will do nothing if all the options with that value are disabled
-   * there's no one with the specified value.
+   * Focus the the specified option
+   * This will do nothing if the option is already focused or not found
+   * The list will scroll to show the focused option if needed.
    *
-   * @param value Value to search the option by
+   * @param option Option to focus
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public selectValue(value: T): boolean {
-    let found = false;
-    const options = this.options.options;
-    for (let i = 0; i < options.length; i++) {
-      if (options[i].value === value) {
-        found = true;
-        const enabled = this.selectIndex(i);
-        if (enabled) {
-          return true;
-        }
-      }
-    }
-
-    return found ? false : this.selectIndex(UNSELECTED_INDEX);
+  public focusOption(option: SelectOption<T>): boolean {
+    return this.focusIndex(this.getIndexFromOption(option));
   }
 
   /**
-   * Select the specified option.
-   * This will do nothing the option is disabled or not found
+   * Focus the option with the specified value
+   * This will do nothing if the option is already focused or not found
+   * The list will scroll to show the focused option if needed.
    *
-   * @param option Explicit option to select
+   * @param value Value to set as selected
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public selectOption(option: SelectOption<T>): boolean {
-    let found = false;
-    const options = this.options.options;
-    for (let i = 0; i < options.length; i++) {
-      if (options[i] === option) {
-        found = true;
-        const enabled = this.selectIndex(i);
-        if (enabled) {
-          return true;
-        }
-      }
-    }
-
-    return found ? false : this.selectIndex(UNSELECTED_INDEX);
+  public focusValue(value: T): boolean {
+    return this.focusIndex(this.getIndexFromValue(value));
   }
 
   /**
-   * Select the previous option to the current one
+   * Focus the previous option to the current one
    *
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public prev(): boolean {
-    return this.moveSelection(-1);
+  public focusPrev(): boolean {
+    return this.moveFocus(-1);
   }
 
   /**
@@ -281,8 +454,8 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    *
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public next(): boolean {
-    return this.moveSelection(+1);
+  public focusNext(): boolean {
+    return this.moveFocus(+1);
   }
 
   /**
@@ -292,55 +465,41 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    * @param changes Object with only the changed options
    */
   protected updateOptions(changes: SelectOptions<T>): void {
-    function fixString(str: string, length: number): string {
-      if (str === undefined) {
-        ' '.repeat(length);
-      }
-      if (str.length === length) {
-        return str;
-      }
-      return str.substr(0, length) + ' '.repeat(length - str.length);
+    // const updateStyle = (state: StyleStates): void => {
+    //   if (changes[state]) {
+    //     this.options[state] = {
+    //       ...Select.defaultOptions[state],
+    //       ...this.options[state],
+    //       ...changes[state],
+    //     };
+    //   }
+    // };
+
+    if (isEmpty(changes)) {
+      return;
     }
 
-    const dirtyText = coalesce(
-      changes.options,
-      changes.width,
-      changes.selectedPrefix,
-      changes.unselectedPrefix,
-    ) !== undefined;
-    const reDraw = coalesce(
-      changes.col,
-      changes.line,
-      changes.height,
-      changes.base,
-      changes.selected,
-      changes.disabled,
-    ) !== undefined;
-    let drawn = false;
+    // updateStyle('baseStyle');
+    // updateStyle('baseFocusedStyle');
+    // updateStyle('selectedStyle');
+    // updateStyle('selectedFocusedStyle');
+    // updateStyle('disabledStyle');
+    // updateStyle('disabledSelectedStyle');
 
-    if (coalesce(changes.selectedPrefix, changes.unselectedPrefix) !== undefined) {
-      const prefixLength = Math.max(
-        this.options.selectedPrefix ? this.options.selectedPrefix.length : 0,
-        this.options.unselectedPrefix ? this.options.unselectedPrefix.length : 0,
-      );
-      this.indentation = ' '.repeat(prefixLength);
-      this.selectedPrefix = fixString(this.options.selectedPrefix, prefixLength);
-      this.unselectedPrefix = fixString(this.options.unselectedPrefix, prefixLength);
-    }
+    let startLine = 0;
+    this.selectOptions = this.options.options.map((option) => {
+      const processedText = splitText(option.text, this.options.width, this.options.tokenizer);
+      const opt = {
+        startLine,
+        processedText,
+        endLine: startLine + processedText.length,
+        option: { ...option },
+        selected: false,
+      };
+      startLine = opt.endLine;
 
-    if (dirtyText && this.options.options) {
-      if (this.indentation === undefined) {
-        this.indentation = '';
-      }
-      const width = this.options.width - this.indentation.length;
-      this.optionsText = this.options.options.map((option) =>
-        splitText(option.text, width, this.options.tokenizer));
-      drawn = this.selectIndex(this.options.selectedIndex);
-    }
-
-    if (!drawn && (dirtyText || reDraw)) {
-      this.render();
-    }
+      return opt;
+    });
   }
 
   /**
@@ -349,37 +508,37 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    * @param delta how many options to "move" (`-1`: previous one, `+1`: next one)
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  private moveSelection(delta: number): boolean {
-    const options = this.options.options;
-    let newIndex = this.selectedIndex;
-    let tries = options.length; // to prevent infinite loop in case there's no available option
+  private moveFocus(delta: number): boolean {
+    const selectOptions = this.selectOptions;
+    let newIndex = this.focusedIndex;
+    let tries = selectOptions.length; // to prevent infinite loop in case there's no available option
 
     do {
       newIndex = newIndex + delta;
 
       if (newIndex < 0) {
         if (this.options.loop) {
-          newIndex = options.length - 1;
+          newIndex = selectOptions.length - 1;
         } else {
           newIndex = 0;
           break;
         }
-      } else if (newIndex >= options.length) {
+      } else if (newIndex >= selectOptions.length) {
         if (this.options.loop) {
           newIndex = 0;
         } else {
-          newIndex = options.length - 1;
+          newIndex = selectOptions.length - 1;
           break;
         }
       }
 
-      if (!options[newIndex].disabled) {
+      if (!selectOptions[newIndex].option.disabled) {
         break;
       }
       tries--;
-    } while (newIndex !== this.selectedIndex && tries > 0);
+    } while (newIndex !== this.focusedIndex && tries > 0);
 
-    return tries > 0 ? this.selectIndex(newIndex) : false;
+    return tries > 0 ? this.focusIndex(newIndex) : false;
   }
 
   /**
@@ -387,16 +546,64 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    *
    * @return `CharStyle` object corresponding to the specified option index
    */
-  private getAspectOptions(optionIndex: number): CharStyle {
-    if (optionIndex === this.selectedIndex) {
-      return this.options.selected;
+  private getOptionStyle(optionIndex: number): SelectOptionStyle {
+    const item = this.selectOptions[optionIndex];
+    const status = ((isSelected, isFocused, isDisabled): StyleStates => {
+      if (isSelected) {
+        if (isDisabled) {
+          return 'disabledSelectedStyle';
+        }
+        if (isFocused) {
+          return 'selectedFocusedStyle';
+        }
+        return 'selectedStyle';
+      }
+
+      if (isDisabled) {
+        return 'disabledStyle';
+      }
+
+      if (isFocused) {
+        return 'baseFocusedStyle';
+      }
+
+      return 'baseStyle';
+    })(item.selected, this.focusedIndex === optionIndex, item.option.disabled);
+
+    return this.options[status];
+  }
+
+  /**
+   * Get the text of an option based in its state
+   *
+   * @param optionIndex
+   */
+  private getOptionText(optionIndex: number): string[] {
+    const item = this.selectOptions[optionIndex];
+    const style = this.getOptionStyle(optionIndex);
+    let width = this.options.width;
+
+    if (style.prefix) {
+      width -= style.prefix.length;
+    }
+    if (style.suffix) {
+      width -= style.suffix.length;
     }
 
-    if (this.options.options[optionIndex] && this.options.options[optionIndex].disabled) {
-      return this.options.disabled;
+    const splittedText = splitText(item.option.text, width, this.options.tokenizer);
+    if (!style.prefix && !style.suffix) {
+      return splittedText;
     }
 
-    return this.options.base;
+    const prefixIndentation = style.prefix ? ' '.repeat(style.prefix.length) : '';
+    const suffixIndentation = style.suffix ? ' '.repeat(style.suffix.length) : '';
+
+    return splittedText.map((line, i) => {
+      const prefix = !style.prefix || i !== 0 ? prefixIndentation : style.prefix;
+      const suffix = !style.suffix || i !== splittedText.length - 1 ? suffixIndentation : style.suffix;
+
+      return prefix + line + suffix;
+    });
   }
 }
 
@@ -406,11 +613,12 @@ export class Select<T> extends Widget<SelectOptions<T>> {
 Select.defaultOptions = {
   options: undefined,
   loop: true,
+  multiple: false,
   allowUnselect: true,
-  base: { fg: '#00ff00', bg: '#000000' },
-  selected: { fg: '#00ff00', bg: '#009900' },
-  disabled: { fg: '#009900', bg: '#000000' },
-  selectedIndex: UNSELECTED_INDEX,
-  selectedPrefix: '',
-  unselectedPrefix: '',
+  baseStyle: { fg: '#00ff00', bg: '#000000', prefix: ' ' },
+  baseFocusedStyle: { fg: '#ffffff', bg: '#000000', prefix: ' ' },
+  selectedStyle: { fg: '#00ff00', bg: '#000000', prefix: '*' },
+  selectedFocusedStyle: { fg: '#ffffff', bg: '#000000', prefix: '*' },
+  disabledStyle: { fg: '#009900', bg: '#000000', prefix: ' ' },
+  disabledSelectedStyle: { fg: '#009900', bg: '#000000', prefix: '*' },
 };

--- a/src/widgets/Select.ts
+++ b/src/widgets/Select.ts
@@ -279,20 +279,10 @@ export class Select<T> extends Widget<SelectOptions<T>> {
       return SELECT_INDEX_NONE;
     }
 
-    let terminalLine = this.options.line;
-    let optionLine = 0;
-    let optionIndex = 0;
-
-    while (optionIndex < this.selectOptions.length && terminalLine < maxHeight) {
-      if (terminalLine === line) {
-        return optionIndex;
-      }
-
-      terminalLine++;
-      optionLine++;
-      if (optionLine >= this.selectOptions[optionIndex].processedText.length) {
-        optionIndex++;
-        optionLine = 0;
+    const realLine = this.firstLine + line - this.options.line;
+    for (let i = 0; i < this.selectOptions.length; i++) {
+      if (this.selectOptions[i].endLine > realLine) {
+        return i;
       }
     }
 


### PR DESCRIPTION
Improvements for the Select widget:

Added new methods:
- `Select.getIndexFrom*`
- `Select.get*FromIndex`
- `Select.getSelected*s`
- `Select.getFocused*`
- `Select.get*At`
- `Select.is*Selected`
- `Select.focus*`

Changed method:
- `Select.select` is now `Select.toggle*`
- `Select.prev` is now `Select.focusPrev`
- `Select.next` is now `Select.focusNext`

(being `*` = `Index` | `Option` | `Value`)

`Select.options` now accept more detailed style descriptions for each style, including `prefix` and `suffix` as new style properties:
- `baseStyle`
- `baseFocusedStyle`
- `selectedStyle`
- `selectedFocusedStyle`
- `disabledStyle`
- `disabledSelectedStyle`