### PR TITLE
Select widget improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Core:
 
 Widgets:
 - Added border feature in `widgets/Grid`
+- Improved `widgets/Select` with new methods and styling options
 
 Others:
 - Added `EventManager.removeListener` (and rename `listen` to `addListener`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,11 @@ And thanks to my lack of empathy this project allows you to have access to a low
 
 ![Input Widget demo](assets/demo-input.gif)
 
-You can check some prepared examples [https://terminal-in-canvas.danikaze.com](already deployed here), and [examples](check their code) to see how to use the library.
+You can check some prepared examples [already deployed here](https://terminal-in-canvas.danikaze.com), and [check their code](./examples) to see how to use the library.
 
 This examples can be built with the `npm run examples` or `yarn examples` command, or just be deployed in the development server via `npm run start` or `yarn start`.
 
-Also, you can check the [docs](api documentation here), if you want to know more details about the library usage.
+Also, you can check the [api documentation here](./docs), if you want to know more details about the library usage.
 
 Changelog
 ---------
@@ -30,6 +30,7 @@ Core:
 Widgets:
 
 *   Added border feature in `widgets/Grid`
+*   Improved `widgets/Select` with new methods and styling options
 
 Others:
 

--- a/docs/classes/_eventmanager_.eventmanager.md
+++ b/docs/classes/_eventmanager_.eventmanager.md
@@ -30,7 +30,7 @@ Manage triggering, listening and bubbling events across the Terminal Widgets
 
 ⊕ **new EventManager**(terminal: *[Terminal](_terminal_.terminal.md)*): [EventManager](_eventmanager_.eventmanager.md)
 
-*Defined in [EventManager.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/EventManager.ts#L14)*
+*Defined in [EventManager.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/EventManager.ts#L14)*
 
 **Parameters:**
 
@@ -50,7 +50,7 @@ ___
 
 ▸ **addListener**(type: *`string`*, listener: *[EventListener](../modules/_eventmanager_.md#eventlistener)*, widget?: *[Widget](_widget_.widget.md)*): `void`
 
-*Defined in [EventManager.ts:27](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/EventManager.ts#L27)*
+*Defined in [EventManager.ts:27](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/EventManager.ts#L27)*
 
 Listen for events of a specific type
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **removeListener**(type: *`string`*, listener: *[EventListener](../modules/_eventmanager_.md#eventlistener)*, widget?: *[Widget](_widget_.widget.md)*): `void`
 
-*Defined in [EventManager.ts:53](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/EventManager.ts#L53)*
+*Defined in [EventManager.ts:53](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/EventManager.ts#L53)*
 
 Remove a previous added listener. Needs to be called with the same parameters as it was added. Does nothing if not found.
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **trigger**(event: *[TerminalEvent](_terminalevent_.terminalevent.md)*, widget?: *[Widget](_widget_.widget.md)*): `void`
 
-*Defined in [EventManager.ts:80](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/EventManager.ts#L80)*
+*Defined in [EventManager.ts:80](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/EventManager.ts#L80)*
 
 Trigger an event. The event will be passed to all the listeners of the target widget and then bubbled to its parent until the root terminal is reached or the event propagation is stopped (`event.stopPropagation`) by one of its listeners
 

--- a/docs/classes/_focusmanager_.focusmanager.md
+++ b/docs/classes/_focusmanager_.focusmanager.md
@@ -32,7 +32,7 @@ Manage the focus behavior around the widgets of a Terminal
 
 ⊕ **new FocusManager**(terminal: *[Terminal](_terminal_.terminal.md)*, canvas: *`HTMLCanvasElement`*): [FocusManager](_focusmanager_.focusmanager.md)
 
-*Defined in [FocusManager.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/FocusManager.ts#L17)*
+*Defined in [FocusManager.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/FocusManager.ts#L17)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **blur**(): `boolean`
 
-*Defined in [FocusManager.ts:93](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/FocusManager.ts#L93)*
+*Defined in [FocusManager.ts:93](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/FocusManager.ts#L93)*
 
 Remove the focus from the current focused widget
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **focus**(newWidget?: *[Widget](_widget_.widget.md)*): `boolean`
 
-*Defined in [FocusManager.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/FocusManager.ts#L47)*
+*Defined in [FocusManager.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/FocusManager.ts#L47)*
 
 Set the specified `newWidget` as focused, and blur the changed part of the path. Instead of setting all the previous path unfocused and then focus the new path, it just unfocus and focus the differences to avoid possible flickering
 
@@ -87,7 +87,7 @@ ___
 
 ▸ **getFocusedWidget**(): [Widget](_widget_.widget.md)
 
-*Defined in [FocusManager.ts:102](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/FocusManager.ts#L102)*
+*Defined in [FocusManager.ts:102](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/FocusManager.ts#L102)*
 
 Retrieve the currently focused widget
 
@@ -101,7 +101,7 @@ ___
 
 ▸ **next**(): `void`
 
-*Defined in [FocusManager.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/FocusManager.ts#L28)*
+*Defined in [FocusManager.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/FocusManager.ts#L28)*
 
 Focus the next widget
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **prev**(): `void`
 
-*Defined in [FocusManager.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/FocusManager.ts#L35)*
+*Defined in [FocusManager.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/FocusManager.ts#L35)*
 
 Focus the previous widget
 

--- a/docs/classes/_terminal_.terminal.md
+++ b/docs/classes/_terminal_.terminal.md
@@ -62,7 +62,7 @@ Basic terminal features rendered into a Canvas object
 
 ⊕ **new Terminal**(canvas: *`HTMLCanvasElement`*, options?: *[TerminalOptions](../interfaces/_terminal_.terminaloptions.md)*): [Terminal](_terminal_.terminal.md)
 
-*Defined in [Terminal.ts:219](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L219)*
+*Defined in [Terminal.ts:219](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L219)*
 
 Creates a Terminal associated to a canvas element.
 
@@ -85,7 +85,7 @@ ___
 
 **● eventManager**: *[EventManager](_eventmanager_.eventmanager.md)*
 
-*Defined in [Terminal.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L191)*
+*Defined in [Terminal.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L191)*
 
 event manager for this terminal
 
@@ -96,7 +96,7 @@ ___
 
 **● focusManager**: *[FocusManager](_focusmanager_.focusmanager.md)*
 
-*Defined in [Terminal.ts:189](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L189)*
+*Defined in [Terminal.ts:189](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L189)*
 
 focus manager for the Terminal widgets
 
@@ -107,7 +107,7 @@ ___
 
 **● options**: *[TerminalOptions](../interfaces/_terminal_.terminaloptions.md)*
 
-*Defined in [Terminal.ts:193](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L193)*
+*Defined in [Terminal.ts:193](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L193)*
 
 terminal options
 
@@ -118,7 +118,7 @@ ___
 
 **● defaultOptions**: *[TerminalOptions](../interfaces/_terminal_.terminaloptions.md)*
 
-*Defined in [Terminal.ts:186](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L186)*
+*Defined in [Terminal.ts:186](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L186)*
 
 Default options for widget instances
 
@@ -134,7 +134,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[__@iterator](../interfaces/_widgetcontainer_.widgetcontainer.md#___iterator)*
 
-*Defined in [Terminal.ts:889](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L889)*
+*Defined in [Terminal.ts:889](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L889)*
 
 Get a bidirectional iterator to move across the attached widgets of the container
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **attachWidget**<`WidgetType`>(WidgetClass: *[WidgetConstructor](../modules/_widget_.md#widgetconstructor)<`WidgetType`>*, options?: *`any`*): `WidgetType`
 
-*Defined in [Terminal.ts:791](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L791)*
+*Defined in [Terminal.ts:791](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L791)*
 
 Create and attach a widget to this instance of the terminal
 
@@ -179,13 +179,13 @@ ___
 
 ▸ **clear**(col: *`number`*, line: *`number`*, width: *`number`*, height: *`number`*): `void`
 
-*Defined in [Terminal.ts:291](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L291)*
+*Defined in [Terminal.ts:291](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L291)*
 
 Clear the whole terminal
 
 **Returns:** `void`
 
-*Defined in [Terminal.ts:301](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L301)*
+*Defined in [Terminal.ts:301](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L301)*
 
 Clear only the specified part of the terminal
 
@@ -209,7 +209,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[dettachWidget](../interfaces/_widgetcontainer_.widgetcontainer.md#dettachwidget)*
 
-*Defined in [Terminal.ts:811](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L811)*
+*Defined in [Terminal.ts:811](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L811)*
 
 Dettach a widget from the terminal
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **getCursor**(): [TilePosition](../interfaces/_terminal_.tileposition.md)
 
-*Defined in [Terminal.ts:493](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L493)*
+*Defined in [Terminal.ts:493](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L493)*
 
 Get the position of the cursor, in tile coordinates
 
@@ -243,7 +243,7 @@ ___
 
 ▸ **getLeafWidgetAt**(column: *`number`*, line: *`number`*): [Widget](_widget_.widget.md)
 
-*Defined in [Terminal.ts:848](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L848)*
+*Defined in [Terminal.ts:848](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L848)*
 
 Traverse the containers to get the last possible widget at the specified position
 
@@ -266,7 +266,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[getParent](../interfaces/_widgetcontainer_.widgetcontainer.md#getparent)*
 
-*Defined in [Terminal.ts:780](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L780)*
+*Defined in [Terminal.ts:780](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L780)*
 
 Get the reference to the parent of the widget, if any
 
@@ -280,7 +280,7 @@ ___
 
 ▸ **getSize**(): [TileSize](../interfaces/_terminal_.tilesize.md)
 
-*Defined in [Terminal.ts:472](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L472)*
+*Defined in [Terminal.ts:472](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L472)*
 
 Get the terminal size, measured in tiles
 
@@ -294,7 +294,7 @@ ___
 
 ▸ **getText**(size?: *`number`*, col?: *`number`*, line?: *`number`*): `string`
 
-*Defined in [Terminal.ts:728](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L728)*
+*Defined in [Terminal.ts:728](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L728)*
 
 Get the text of the terminal. By default gets the text from the current position of the cursor. If the `size` is reaches the end of the line, it will continue in the next one.
 
@@ -315,7 +315,7 @@ ___
 
 ▸ **getTextStyle**(): [CharStyle](../interfaces/_terminal_.charstyle.md)
 
-*Defined in [Terminal.ts:582](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L582)*
+*Defined in [Terminal.ts:582](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L582)*
 
 Get the current style being applied to the `setText` calls
 
@@ -328,7 +328,7 @@ ___
 
 ▸ **getTilePosition**(x: *`number`*, y: *`number`*): [TilePosition](../interfaces/_terminal_.tileposition.md)
 
-*Defined in [Terminal.ts:561](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L561)*
+*Defined in [Terminal.ts:561](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L561)*
 
 Given a position in pixels relative to the top-left corner of the terminal, get the corresponding tile
 
@@ -348,7 +348,7 @@ ___
 
 ▸ **getViewport**(): [ViewPortOptions](../interfaces/_terminal_.viewportoptions.md)
 
-*Defined in [Terminal.ts:463](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L463)*
+*Defined in [Terminal.ts:463](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L463)*
 
 Get the drawing limits (viewport) of the terminal
 
@@ -364,7 +364,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[getWidgetAt](../interfaces/_widgetcontainer_.widgetcontainer.md#getwidgetat)*
 
-*Defined in [Terminal.ts:831](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L831)*
+*Defined in [Terminal.ts:831](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L831)*
 
 Get a previously attached widget by its position
 
@@ -385,7 +385,7 @@ ___
 
 ▸ **getWidgetPath**(widget: *[Widget](_widget_.widget.md)*): `Array`< [Widget](_widget_.widget.md) &#124; [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md)>
 
-*Defined in [Terminal.ts:872](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L872)*
+*Defined in [Terminal.ts:872](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L872)*
 
 Get the list of widgets from the widget until the terminal itself (not included) The result will be `undefined` if the widget is not found as a descendant of this terminal
 
@@ -405,7 +405,7 @@ ___
 
 ▸ **isCursorEnabled**(): `boolean`
 
-*Defined in [Terminal.ts:484](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L484)*
+*Defined in [Terminal.ts:484](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L484)*
 
 Get the current status of the cursor
 
@@ -419,7 +419,7 @@ ___
 
 ▸ **moveCursor**(dx: *`number`*, dy: *`number`*): `void`
 
-*Defined in [Terminal.ts:550](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L550)*
+*Defined in [Terminal.ts:550](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L550)*
 
 Set the new position of the cursor, relative to the current one
 
@@ -439,7 +439,7 @@ ___
 
 ▸ **render**(): `void`
 
-*Defined in [Terminal.ts:359](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L359)*
+*Defined in [Terminal.ts:359](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L359)*
 
 Render the terminal status into the canvas context. It works with a list of _dirty_ tiles so it only renders what's changed.
 
@@ -454,7 +454,7 @@ ___
 
 ▸ **renderAll**(): `void`
 
-*Defined in [Terminal.ts:448](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L448)*
+*Defined in [Terminal.ts:448](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L448)*
 
 Forces a render of all the tiles, not only the changed ones
 
@@ -467,7 +467,7 @@ ___
 
 ▸ **setCursor**(col: *`number`*, line: *`number`*): `void`
 
-*Defined in [Terminal.ts:506](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L506)*
+*Defined in [Terminal.ts:506](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L506)*
 
 Set the new position of the cursor
 
@@ -487,7 +487,7 @@ ___
 
 ▸ **setImage**(img: *[AcceptedImage](../modules/_terminal_.md#acceptedimage)*, col?: *`number`*, line?: *`number`*, offset?: *[ImageOffset](../interfaces/_terminal_.imageoffset.md)*, size?: *[ImageSize](../interfaces/_terminal_.imagesize.md)*, crop?: *[ImageCropParams](../interfaces/_terminal_.imagecropparams.md)*): `void`
 
-*Defined in [Terminal.ts:706](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L706)*
+*Defined in [Terminal.ts:706](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L706)*
 
 Draws an image to the terminal.
 
@@ -511,7 +511,7 @@ ___
 
 ▸ **setOptions**(options: *[TerminalOptions](../interfaces/_terminal_.terminaloptions.md)*): `void`
 
-*Defined in [Terminal.ts:247](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L247)*
+*Defined in [Terminal.ts:247](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L247)*
 
 Update the values of the Terminal options
 
@@ -530,7 +530,7 @@ ___
 
 ▸ **setText**(text: *`string`*, col?: *`number`*, line?: *`number`*): `void`
 
-*Defined in [Terminal.ts:605](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L605)*
+*Defined in [Terminal.ts:605](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L605)*
 
 Input a simple text in the terminal. By default the text will be set in the current position of the cursor. If the text reaches the right side of the terminal, will break into a new line as is (there's no word begin-end control when breaking a word). There's no character escape done (such as \\n)
 
@@ -551,7 +551,7 @@ ___
 
 ▸ **setTextStyle**(style: *[CharStyle](../interfaces/_terminal_.charstyle.md)*): `void`
 
-*Defined in [Terminal.ts:575](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L575)*
+*Defined in [Terminal.ts:575](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L575)*
 
 Set the style to apply in the `setText` calls. Passed `style` object can have other properties, but only the ones related to the style will be applied.
 
@@ -570,7 +570,7 @@ ___
 
 ▸ **setTiles**(tiles: * [TextTile](../interfaces/_terminal_.texttile.md) &#124; [TextTile](../interfaces/_terminal_.texttile.md)[] &#124; [ImageTile](../interfaces/_terminal_.imagetile.md) &#124; [ImageTile](../interfaces/_terminal_.imagetile.md)[]*, col?: *`number`*, line?: *`number`*): `void`
 
-*Defined in [Terminal.ts:755](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L755)*
+*Defined in [Terminal.ts:755](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L755)*
 
 Works like `setText` but specifying all the properties of a tile, not only the text.
 

--- a/docs/classes/_terminalevent_.terminalevent.md
+++ b/docs/classes/_terminalevent_.terminalevent.md
@@ -34,7 +34,7 @@ Type of Events that can be triggered on Terminal's widgets, and bubble through i
 
 ⊕ **new TerminalEvent**(options: * [EventOptions](../interfaces/_terminalevent_.eventoptions.md) &#124; `string`*, data?: *`any`*): [TerminalEvent](_terminalevent_.terminalevent.md)
 
-*Defined in [TerminalEvent.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L18)*
+*Defined in [TerminalEvent.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L18)*
 
 **Parameters:**
 
@@ -55,7 +55,7 @@ ___
 
 **● data**: *`any`*
 
-*Defined in [TerminalEvent.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L13)*
+*Defined in [TerminalEvent.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L13)*
 
 Data that can be passed from the trigger moment to the listeners
 
@@ -66,7 +66,7 @@ ___
 
 **● type**: *`string`*
 
-*Defined in [TerminalEvent.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L11)*
+*Defined in [TerminalEvent.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L11)*
 
 Event type. Used to listen for this kind of events when triggered
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **isCancelled**(): `boolean`
 
-*Defined in [TerminalEvent.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L47)*
+*Defined in [TerminalEvent.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L47)*
 
 Check if the event is still propagating
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **stopPropagation**(): `void`
 
-*Defined in [TerminalEvent.ts:36](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L36)*
+*Defined in [TerminalEvent.ts:36](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L36)*
 
 Stops the propagation of the event. Called from a listener so the event is not passed to the next one.
 

--- a/docs/classes/_widget_.widget.md
+++ b/docs/classes/_widget_.widget.md
@@ -62,7 +62,7 @@ A widget is just a self-contained graphic part of the terminal, which manages it
 
 ⊕ **new Widget**(terminal: *[Terminal](_terminal_.terminal.md)*, options?: *`OptionsType`*, parent?: *[WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md)*): [Widget](_widget_.widget.md)
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 A Widget is created in the context of a specific terminal, in a position and with a provided height
 
@@ -86,7 +86,7 @@ ___
 
 **● allocated**: *`boolean`*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -97,7 +97,7 @@ ___
 
 **● focused**: *`boolean`*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -108,7 +108,7 @@ ___
 
 **● options**: *`OptionsType`* =  {} as any
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -119,7 +119,7 @@ ___
 
 **● parent**: *[WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -130,7 +130,7 @@ ___
 
 **● terminal**: *[Terminal](_terminal_.terminal.md)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -141,7 +141,7 @@ ___
 
 **● defaultOptions**: *[WidgetOptions](../interfaces/_widget_.widgetoptions.md)*
 
-*Defined in [Widget.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L28)*
+*Defined in [Widget.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L28)*
 
 Default options for widget instances
 
@@ -155,7 +155,7 @@ ___
 
 ▸ **blur**(): `boolean`
 
-*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L176)*
+*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L176)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -169,7 +169,7 @@ ___
 
 ▸ **destruct**(): `void`
 
-*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L61)*
+*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L61)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **focus**(): `boolean`
 
-*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L156)*
+*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L156)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
@@ -196,7 +196,7 @@ ___
 
 ▸ **getParent**(): [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md)
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -210,7 +210,7 @@ ___
 
 ▸ **getPosition**(): [TilePosition](../interfaces/_terminal_.tileposition.md)
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -224,7 +224,7 @@ ___
 
 ▸ **getSize**(): [TileSize](../interfaces/_terminal_.tilesize.md)
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
@@ -238,7 +238,7 @@ ___
 
 ▸ **isAt**(column: *`number`*, line: *`number`*): `boolean`
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -259,7 +259,7 @@ ___
 
 ▸ **isFocusable**(): `boolean`
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -273,7 +273,7 @@ ___
 
 ▸ **isFocused**(): `boolean`
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **render**(): `void`
 
-*Defined in [Widget.ts:198](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L198)*
+*Defined in [Widget.ts:198](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L198)*
 
 Render the widget in the associated terminal (if any)
 
@@ -300,7 +300,7 @@ ___
 
 ▸ **setOptions**(options: *`OptionsType`*): `void`
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -324,7 +324,7 @@ ___
 
 ▸ **updateOptions**(changedOptions: *`OptionsType`*): `void`
 
-*Defined in [Widget.ts:206](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L206)*
+*Defined in [Widget.ts:206](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L206)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/classes/_widgets_box_.box.md
+++ b/docs/classes/_widgets_box_.box.md
@@ -60,7 +60,7 @@ Very basic `WidgetContainer` which draws a box around the attached content. It a
 
 *Overrides [Widget](_widget_.widget.md).[constructor](_widget_.widget.md#constructor)*
 
-*Defined in [widgets/Box.ts:102](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L102)*
+*Defined in [widgets/Box.ts:102](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L102)*
 
 **Parameters:**
 
@@ -84,7 +84,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[allocated](_widget_.widget.md#allocated)*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focused](_widget_.widget.md#focused)*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -110,7 +110,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[options](_widget_.widget.md#options)*
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[parent](_widget_.widget.md#parent)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[terminal](_widget_.widget.md#terminal)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -149,7 +149,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[defaultOptions](_widget_.widget.md#defaultoptions)*
 
-*Defined in [widgets/Box.ts:82](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L82)*
+*Defined in [widgets/Box.ts:82](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L82)*
 
 Default options for widget instances
 
@@ -165,7 +165,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[__@iterator](../interfaces/_widgetcontainer_.widgetcontainer.md#___iterator)*
 
-*Defined in [widgets/Box.ts:211](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L211)*
+*Defined in [widgets/Box.ts:211](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L211)*
 
 Get a bidirectional iterator to move across the attached widgets of the container
 
@@ -184,7 +184,7 @@ ___
 
 ▸ **attachWidget**<`WidgetType`>(WidgetClass: *[WidgetConstructor](../modules/_widget_.md#widgetconstructor)<`WidgetType`>*, options: *`any`*): `WidgetType`
 
-*Defined in [widgets/Box.ts:147](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L147)*
+*Defined in [widgets/Box.ts:147](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L147)*
 
 Create and attach a widget to this instance of the terminal
 
@@ -210,7 +210,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[blur](_widget_.widget.md#blur)*
 
-*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L176)*
+*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L176)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -226,7 +226,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[destruct](_widget_.widget.md#destruct)*
 
-*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L61)*
+*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L61)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -241,7 +241,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[dettachWidget](../interfaces/_widgetcontainer_.widgetcontainer.md#dettachwidget)*
 
-*Defined in [widgets/Box.ts:171](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L171)*
+*Defined in [widgets/Box.ts:171](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L171)*
 
 Dettach a widget from the container
 
@@ -263,7 +263,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focus](_widget_.widget.md#focus)*
 
-*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L156)*
+*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L156)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
@@ -281,7 +281,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getParent](_widget_.widget.md#getparent)*
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -297,7 +297,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getPosition](_widget_.widget.md#getposition)*
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -313,7 +313,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getSize](_widget_.widget.md#getsize)*
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
@@ -329,7 +329,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[getWidgetAt](../interfaces/_widgetcontainer_.widgetcontainer.md#getwidgetat)*
 
-*Defined in [widgets/Box.ts:200](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L200)*
+*Defined in [widgets/Box.ts:200](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L200)*
 
 Get a previously attached widget by its position
 
@@ -352,7 +352,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isAt](_widget_.widget.md#isat)*
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -375,7 +375,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocusable](_widget_.widget.md#isfocusable)*
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -391,7 +391,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocused](_widget_.widget.md#isfocused)*
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -407,7 +407,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[render](_widget_.widget.md#render)*
 
-*Defined in [widgets/Box.ts:115](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L115)*
+*Defined in [widgets/Box.ts:115](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L115)*
 
 Render the widget in the associated terminal
 
@@ -422,7 +422,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[setOptions](_widget_.widget.md#setoptions)*
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -448,7 +448,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[updateOptions](_widget_.widget.md#updateoptions)*
 
-*Defined in [widgets/Box.ts:262](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L262)*
+*Defined in [widgets/Box.ts:262](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L262)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/classes/_widgets_grid_.grid.md
+++ b/docs/classes/_widgets_grid_.grid.md
@@ -63,7 +63,7 @@ Provides a dynamic grid system for Terminal Widgets
 
 *Overrides [Widget](_widget_.widget.md).[constructor](_widget_.widget.md#constructor)*
 
-*Defined in [widgets/Grid.ts:80](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L80)*
+*Defined in [widgets/Grid.ts:80](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L80)*
 
 **Parameters:**
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[allocated](_widget_.widget.md#allocated)*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -100,7 +100,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focused](_widget_.widget.md#focused)*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -113,7 +113,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[options](_widget_.widget.md#options)*
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -126,7 +126,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[parent](_widget_.widget.md#parent)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -139,7 +139,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[terminal](_widget_.widget.md#terminal)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -152,7 +152,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[defaultOptions](_widget_.widget.md#defaultoptions)*
 
-*Defined in [widgets/Grid.ts:71](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L71)*
+*Defined in [widgets/Grid.ts:71](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L71)*
 
 Default options for widget instances
 
@@ -168,7 +168,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[__@iterator](../interfaces/_widgetcontainer_.widgetcontainer.md#___iterator)*
 
-*Defined in [widgets/Grid.ts:219](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L219)*
+*Defined in [widgets/Grid.ts:219](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L219)*
 
 Get a bidirectional iterator to move across the attached widgets of the container
 
@@ -187,7 +187,7 @@ ___
 
 ▸ **align**(): `void`
 
-*Defined in [widgets/Grid.ts:141](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L141)*
+*Defined in [widgets/Grid.ts:141](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L141)*
 
 Do the calculation of the real size of the attached widgets Widgets won't be placed properly until this method is not called (to avoid duplicated calculations) This is called automatically when using `attachWidget` but is provided in case it needs to be called manually
 
@@ -200,7 +200,7 @@ ___
 
 ▸ **attachWidget**<`WidgetType`>(col: *`number`*, line: *`number`*, width: *`number`*, height: *`number`*, WidgetClass: *[WidgetConstructor](../modules/_widget_.md#widgetconstructor)<`WidgetType`>*, options: *`any`*): `WidgetType`
 
-*Defined in [widgets/Grid.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L156)*
+*Defined in [widgets/Grid.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L156)*
 
 Attach a widget to the grid
 
@@ -230,7 +230,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[blur](_widget_.widget.md#blur)*
 
-*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L176)*
+*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L176)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -246,7 +246,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[destruct](_widget_.widget.md#destruct)*
 
-*Defined in [widgets/Grid.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L118)*
+*Defined in [widgets/Grid.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L118)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -261,7 +261,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[dettachWidget](../interfaces/_widgetcontainer_.widgetcontainer.md#dettachwidget)*
 
-*Defined in [widgets/Grid.ts:184](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L184)*
+*Defined in [widgets/Grid.ts:184](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L184)*
 
 Dettach a widget from this terminal
 
@@ -283,7 +283,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focus](_widget_.widget.md#focus)*
 
-*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L156)*
+*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L156)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
@@ -297,7 +297,7 @@ ___
 
 ▸ **getCellSize**(column: *`number`*, line: *`number`*): [TileSize](../interfaces/_terminal_.tilesize.md)
 
-*Defined in [widgets/Grid.ts:287](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L287)*
+*Defined in [widgets/Grid.ts:287](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L287)*
 
 Get the size of a cell of the grid in tiles
 
@@ -322,7 +322,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getParent](_widget_.widget.md#getparent)*
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -338,7 +338,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getPosition](_widget_.widget.md#getposition)*
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -354,7 +354,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getSize](_widget_.widget.md#getsize)*
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
@@ -370,7 +370,7 @@ ___
 
 *Implementation of [WidgetContainer](../interfaces/_widgetcontainer_.widgetcontainer.md).[getWidgetAt](../interfaces/_widgetcontainer_.widgetcontainer.md#getwidgetat)*
 
-*Defined in [widgets/Grid.ts:204](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L204)*
+*Defined in [widgets/Grid.ts:204](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L204)*
 
 Get a previously attached widget by its position in the terminal
 
@@ -391,7 +391,7 @@ ___
 
 ▸ **getWidgetGrid**(column: *`number`*, line: *`number`*): [Widget](_widget_.widget.md)
 
-*Defined in [widgets/Grid.ts:271](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L271)*
+*Defined in [widgets/Grid.ts:271](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L271)*
 
 Get a previously attached widget by its position in the Grid
 
@@ -414,7 +414,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isAt](_widget_.widget.md#isat)*
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -437,7 +437,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocusable](_widget_.widget.md#isfocusable)*
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -453,7 +453,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocused](_widget_.widget.md#isfocused)*
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -469,7 +469,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[render](_widget_.widget.md#render)*
 
-*Defined in [widgets/Grid.ts:126](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L126)*
+*Defined in [widgets/Grid.ts:126](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L126)*
 
 Render all the attached widgets to the grid
 
@@ -484,7 +484,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[setOptions](_widget_.widget.md#setoptions)*
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -510,7 +510,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[updateOptions](_widget_.widget.md#updateoptions)*
 
-*Defined in [widgets/Grid.ts:300](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L300)*
+*Defined in [widgets/Grid.ts:300](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L300)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/classes/_widgets_input_.input.md
+++ b/docs/classes/_widgets_input_.input.md
@@ -54,7 +54,7 @@ One line text input widget
 
 *Overrides [Widget](_widget_.widget.md).[constructor](_widget_.widget.md#constructor)*
 
-*Defined in [widgets/Input.ts:29](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L29)*
+*Defined in [widgets/Input.ts:29](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L29)*
 
 **Parameters:**
 
@@ -78,7 +78,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[allocated](_widget_.widget.md#allocated)*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -91,7 +91,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focused](_widget_.widget.md#focused)*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -104,7 +104,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[options](_widget_.widget.md#options)*
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[parent](_widget_.widget.md#parent)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[terminal](_widget_.widget.md#terminal)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -143,7 +143,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[defaultOptions](_widget_.widget.md#defaultoptions)*
 
-*Defined in [widgets/Input.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L22)*
+*Defined in [widgets/Input.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L22)*
 
 Default options for widget instances
 
@@ -159,7 +159,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[blur](_widget_.widget.md#blur)*
 
-*Defined in [widgets/Input.ts:101](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L101)*
+*Defined in [widgets/Input.ts:101](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L101)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -174,7 +174,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[destruct](_widget_.widget.md#destruct)*
 
-*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L61)*
+*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L61)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -189,7 +189,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[focus](_widget_.widget.md#focus)*
 
-*Defined in [widgets/Input.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L86)*
+*Defined in [widgets/Input.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L86)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
@@ -204,7 +204,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getParent](_widget_.widget.md#getparent)*
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -220,7 +220,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getPosition](_widget_.widget.md#getposition)*
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -236,7 +236,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getSize](_widget_.widget.md#getsize)*
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
@@ -250,7 +250,7 @@ ___
 
 ▸ **getValue**(showPassword?: *`boolean`*): `string`
 
-*Defined in [widgets/Input.ts:63](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L63)*
+*Defined in [widgets/Input.ts:63](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L63)*
 
 Get the current value of the input text
 
@@ -272,7 +272,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isAt](_widget_.widget.md#isat)*
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -295,7 +295,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocusable](_widget_.widget.md#isfocusable)*
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -311,7 +311,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocused](_widget_.widget.md#isfocused)*
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -327,7 +327,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[render](_widget_.widget.md#render)*
 
-*Defined in [widgets/Input.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L42)*
+*Defined in [widgets/Input.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L42)*
 
 Render the widget in the associated terminal
 
@@ -342,7 +342,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[setOptions](_widget_.widget.md#setoptions)*
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -366,7 +366,7 @@ ___
 
 ▸ **setValue**(value: *`string`*): `void`
 
-*Defined in [widgets/Input.ts:74](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L74)*
+*Defined in [widgets/Input.ts:74](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L74)*
 
 Set the new value of the input text
 
@@ -387,7 +387,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[updateOptions](_widget_.widget.md#updateoptions)*
 
-*Defined in [widgets/Input.ts:117](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L117)*
+*Defined in [widgets/Input.ts:117](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L117)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/classes/_widgets_progressbar_.progressbar.md
+++ b/docs/classes/_widgets_progressbar_.progressbar.md
@@ -53,7 +53,7 @@ Display a progress bar
 
 *Overrides [Widget](_widget_.widget.md).[constructor](_widget_.widget.md#constructor)*
 
-*Defined in [widgets/ProgressBar.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L31)*
+*Defined in [widgets/ProgressBar.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L31)*
 
 **Parameters:**
 
@@ -77,7 +77,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[allocated](_widget_.widget.md#allocated)*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -90,7 +90,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focused](_widget_.widget.md#focused)*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -103,7 +103,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[options](_widget_.widget.md#options)*
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -116,7 +116,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[parent](_widget_.widget.md#parent)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -129,7 +129,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[terminal](_widget_.widget.md#terminal)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -142,7 +142,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[defaultOptions](_widget_.widget.md#defaultoptions)*
 
-*Defined in [widgets/ProgressBar.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L31)*
+*Defined in [widgets/ProgressBar.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L31)*
 
 Default options for widget instances
 
@@ -158,7 +158,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[blur](_widget_.widget.md#blur)*
 
-*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L176)*
+*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L176)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -174,7 +174,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[destruct](_widget_.widget.md#destruct)*
 
-*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L61)*
+*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L61)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -189,7 +189,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focus](_widget_.widget.md#focus)*
 
-*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L156)*
+*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L156)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
@@ -205,7 +205,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getParent](_widget_.widget.md#getparent)*
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getPosition](_widget_.widget.md#getposition)*
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -235,7 +235,7 @@ ___
 
 ▸ **getProgress**(): `number`
 
-*Defined in [widgets/ProgressBar.ts:55](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L55)*
+*Defined in [widgets/ProgressBar.ts:55](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L55)*
 
 Retrieve a reference to the currently selected option
 
@@ -250,7 +250,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getSize](_widget_.widget.md#getsize)*
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
@@ -266,7 +266,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isAt](_widget_.widget.md#isat)*
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -289,7 +289,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocusable](_widget_.widget.md#isfocusable)*
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -305,7 +305,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocused](_widget_.widget.md#isfocused)*
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -321,7 +321,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[render](_widget_.widget.md#render)*
 
-*Defined in [widgets/ProgressBar.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L44)*
+*Defined in [widgets/ProgressBar.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L44)*
 
 Render the widget in the associated terminal
 
@@ -336,7 +336,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[setOptions](_widget_.widget.md#setoptions)*
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -362,7 +362,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[updateOptions](_widget_.widget.md#updateoptions)*
 
-*Defined in [widgets/ProgressBar.ts:65](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L65)*
+*Defined in [widgets/ProgressBar.ts:65](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L65)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/classes/_widgets_select_.select.md
+++ b/docs/classes/_widgets_select_.select.md
@@ -2,7 +2,7 @@
 
 # Class: Select
 
-Display a list of selectable options
+Display a list of selectable options. The focused option is where the cursor is. It can be none or one at most. Selected options can be none, one or, if the `multiple` option is `true`, more than one at the same time
 
 ## Type parameters
 #### T 
@@ -32,22 +32,38 @@ Display a list of selectable options
 * [blur](_widgets_select_.select.md#blur)
 * [destruct](_widgets_select_.select.md#destruct)
 * [focus](_widgets_select_.select.md#focus)
+* [focusIndex](_widgets_select_.select.md#focusindex)
+* [focusNext](_widgets_select_.select.md#focusnext)
+* [focusOption](_widgets_select_.select.md#focusoption)
+* [focusPrev](_widgets_select_.select.md#focusprev)
+* [focusValue](_widgets_select_.select.md#focusvalue)
+* [getFocusedIndex](_widgets_select_.select.md#getfocusedindex)
+* [getFocusedOption](_widgets_select_.select.md#getfocusedoption)
+* [getFocusedValue](_widgets_select_.select.md#getfocusedvalue)
+* [getIndexAt](_widgets_select_.select.md#getindexat)
+* [getIndexFromOption](_widgets_select_.select.md#getindexfromoption)
+* [getIndexFromValue](_widgets_select_.select.md#getindexfromvalue)
 * [getOptionAt](_widgets_select_.select.md#getoptionat)
+* [getOptionFromIndex](_widgets_select_.select.md#getoptionfromindex)
 * [getParent](_widgets_select_.select.md#getparent)
 * [getPosition](_widgets_select_.select.md#getposition)
-* [getSelectedIndex](_widgets_select_.select.md#getselectedindex)
-* [getSelectedOption](_widgets_select_.select.md#getselectedoption)
+* [getSelectedIndexes](_widgets_select_.select.md#getselectedindexes)
+* [getSelectedOptions](_widgets_select_.select.md#getselectedoptions)
+* [getSelectedValues](_widgets_select_.select.md#getselectedvalues)
 * [getSize](_widgets_select_.select.md#getsize)
+* [getValueAt](_widgets_select_.select.md#getvalueat)
+* [getValueFromIndex](_widgets_select_.select.md#getvaluefromindex)
 * [isAt](_widgets_select_.select.md#isat)
 * [isFocusable](_widgets_select_.select.md#isfocusable)
 * [isFocused](_widgets_select_.select.md#isfocused)
-* [next](_widgets_select_.select.md#next)
-* [prev](_widgets_select_.select.md#prev)
+* [isIndexSelected](_widgets_select_.select.md#isindexselected)
+* [isOptionSelected](_widgets_select_.select.md#isoptionselected)
+* [isValueSelected](_widgets_select_.select.md#isvalueselected)
 * [render](_widgets_select_.select.md#render)
-* [selectIndex](_widgets_select_.select.md#selectindex)
 * [selectOption](_widgets_select_.select.md#selectoption)
 * [selectValue](_widgets_select_.select.md#selectvalue)
 * [setOptions](_widgets_select_.select.md#setoptions)
+* [toggleIndex](_widgets_select_.select.md#toggleindex)
 * [updateOptions](_widgets_select_.select.md#updateoptions)
 
 ---
@@ -62,7 +78,7 @@ Display a list of selectable options
 
 *Overrides [Widget](_widget_.widget.md).[constructor](_widget_.widget.md#constructor)*
 
-*Defined in [widgets/Select.ts:54](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L54)*
+*Defined in [widgets/Select.ts:93](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L93)*
 
 **Parameters:**
 
@@ -86,7 +102,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[allocated](_widget_.widget.md#allocated)*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -99,7 +115,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focused](_widget_.widget.md#focused)*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -112,7 +128,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[options](_widget_.widget.md#options)*
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -125,7 +141,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[parent](_widget_.widget.md#parent)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -138,7 +154,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[terminal](_widget_.widget.md#terminal)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -151,7 +167,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[defaultOptions](_widget_.widget.md#defaultoptions)*
 
-*Defined in [widgets/Select.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L47)*
+*Defined in [widgets/Select.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L86)*
 
 Default options for widget instances
 
@@ -167,7 +183,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[blur](_widget_.widget.md#blur)*
 
-*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L176)*
+*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L176)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -183,7 +199,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[destruct](_widget_.widget.md#destruct)*
 
-*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L61)*
+*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L61)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -198,12 +214,203 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focus](_widget_.widget.md#focus)*
 
-*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L156)*
+*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L156)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
 **Returns:** `boolean`
 `true` if it wasn't focused and focused properly
+
+___
+<a id="focusindex"></a>
+
+###  focusIndex
+
+▸ **focusIndex**(index: *`number`*): `boolean`
+
+*Defined in [widgets/Select.ts:416](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L416)*
+
+Focus the option with the specified index. This will do nothing if the option is already focused or the index is invalid. The list will scroll to show the focused option if needed.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| index | `number` |  New index to set as selected (starting on 0) |
+
+**Returns:** `boolean`
+`true` if the selected option has changed, `false` otherwise
+
+___
+<a id="focusnext"></a>
+
+###  focusNext
+
+▸ **focusNext**(): `boolean`
+
+*Defined in [widgets/Select.ts:483](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L483)*
+
+Select the next option to the current one
+
+**Returns:** `boolean`
+`true` if the selected option has changed, `false` otherwise
+
+___
+<a id="focusoption"></a>
+
+###  focusOption
+
+▸ **focusOption**(option: *[SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>*): `boolean`
+
+*Defined in [widgets/Select.ts:453](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L453)*
+
+Focus the the specified option This will do nothing if the option is already focused or not found The list will scroll to show the focused option if needed.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| option | [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`> |  Option to focus |
+
+**Returns:** `boolean`
+`true` if the selected option has changed, `false` otherwise
+
+___
+<a id="focusprev"></a>
+
+###  focusPrev
+
+▸ **focusPrev**(): `boolean`
+
+*Defined in [widgets/Select.ts:474](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L474)*
+
+Focus the previous option to the current one
+
+**Returns:** `boolean`
+`true` if the selected option has changed, `false` otherwise
+
+___
+<a id="focusvalue"></a>
+
+###  focusValue
+
+▸ **focusValue**(value: *`T`*): `boolean`
+
+*Defined in [widgets/Select.ts:465](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L465)*
+
+Focus the option with the specified value This will do nothing if the option is already focused or not found The list will scroll to show the focused option if needed.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| value | `T` |  Value to set as selected |
+
+**Returns:** `boolean`
+`true` if the selected option has changed, `false` otherwise
+
+___
+<a id="getfocusedindex"></a>
+
+###  getFocusedIndex
+
+▸ **getFocusedIndex**(): `number`
+
+*Defined in [widgets/Select.ts:245](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L245)*
+
+Retrieve the index of the focused option
+
+**Returns:** `number`
+index of the selected option or `UNSELECTED_INDEX` if no one is selected
+
+___
+<a id="getfocusedoption"></a>
+
+###  getFocusedOption
+
+▸ **getFocusedOption**(): [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
+
+*Defined in [widgets/Select.ts:254](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L254)*
+
+Retrieve the focused option
+
+**Returns:** [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
+Reference to the given focused option, or `undefined` if nothing is selected
+
+___
+<a id="getfocusedvalue"></a>
+
+###  getFocusedValue
+
+▸ **getFocusedValue**(): `T`
+
+*Defined in [widgets/Select.ts:263](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L263)*
+
+Retrieve the value of the focused option
+
+**Returns:** `T`
+Reference to the given focused option value, or `undefined` if nothing is selected
+
+___
+<a id="getindexat"></a>
+
+###  getIndexAt
+
+▸ **getIndexAt**(column: *`number`*, line: *`number`*): `number`
+
+*Defined in [widgets/Select.ts:274](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L274)*
+
+Get the index of the option at the specified terminal position (absolute)
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| column | `number` |  column of the terminal |
+| line | `number` |  line of the terminal |
+
+**Returns:** `number`
+index of the option or `INDEX_NONE` if not found
+
+___
+<a id="getindexfromoption"></a>
+
+###  getIndexFromOption
+
+▸ **getIndexFromOption**(option: *[SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>*): `number`
+
+*Defined in [widgets/Select.ts:177](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L177)*
+
+Get the index of the desired option
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| option | [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`> |  option to search |
+
+**Returns:** `number`
+Index of the option in the select list or `INDEX_NONE` if not found
+
+___
+<a id="getindexfromvalue"></a>
+
+###  getIndexFromValue
+
+▸ **getIndexFromValue**(value: *`T`*): `number`
+
+*Defined in [widgets/Select.ts:193](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L193)*
+
+Get the index of the desired value
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| value | `T` |  value to search |
+
+**Returns:** `number`
+Index of the option in the select list or `INDEX_NONE` if not found
 
 ___
 <a id="getoptionat"></a>
@@ -212,7 +419,7 @@ ___
 
 ▸ **getOptionAt**(column: *`number`*, line: *`number`*): [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
 
-*Defined in [widgets/Select.ts:136](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L136)*
+*Defined in [widgets/Select.ts:299](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L299)*
 
 Get the option at the specified terminal position (absolute)
 
@@ -227,6 +434,26 @@ Get the option at the specified terminal position (absolute)
 option or `undefined` if not found
 
 ___
+<a id="getoptionfromindex"></a>
+
+###  getOptionFromIndex
+
+▸ **getOptionFromIndex**(index: *`number`*): [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
+
+*Defined in [widgets/Select.ts:153](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L153)*
+
+Get the provided option from the specified index
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| index | `number` |  index of the desired option |
+
+**Returns:** [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
+Reference to a copy of the provided option
+
+___
 <a id="getparent"></a>
 
 ###  getParent
@@ -235,7 +462,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getParent](_widget_.widget.md#getparent)*
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -251,7 +478,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getPosition](_widget_.widget.md#getposition)*
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -259,32 +486,46 @@ Get the position of the widget, in tile coordinates
 current position of the widget, in tile coordinates
 
 ___
-<a id="getselectedindex"></a>
+<a id="getselectedindexes"></a>
 
-###  getSelectedIndex
+###  getSelectedIndexes
 
-▸ **getSelectedIndex**(): `number`
+▸ **getSelectedIndexes**(): `number`[]
 
-*Defined in [widgets/Select.ts:125](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L125)*
+*Defined in [widgets/Select.ts:208](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L208)*
 
-Retrieve the index of the currently selected option
+Retrieve a list of indexes of the selected options.
 
-**Returns:** `number`
-index of the selected option or `UNSELECTED_INDEX` if no one is selected
+**Returns:** `number`[]
+Indexes of the selected options
 
 ___
-<a id="getselectedoption"></a>
+<a id="getselectedoptions"></a>
 
-###  getSelectedOption
+###  getSelectedOptions
 
-▸ **getSelectedOption**(): [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
+▸ **getSelectedOptions**(): [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>[]
 
-*Defined in [widgets/Select.ts:116](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L116)*
+*Defined in [widgets/Select.ts:227](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L227)*
 
-Retrieve a reference to the currently selected option. Even if it's a reference, don't update it directly, but use `setOptions` to allow the widget to apply the changes
+Retrieve a list of selected options. Even if this is a list of references to the given options, refrain of modifying them directly. Use `setOptions` instead.
 
-**Returns:** [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>
-Object specified in `options.options`.
+**Returns:** [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>[]
+List of selected options
+
+___
+<a id="getselectedvalues"></a>
+
+###  getSelectedValues
+
+▸ **getSelectedValues**(): `T`[]
+
+*Defined in [widgets/Select.ts:236](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L236)*
+
+Retrieve a list of selected values.
+
+**Returns:** `T`[]
+List of selected values
 
 ___
 <a id="getsize"></a>
@@ -295,12 +536,53 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getSize](_widget_.widget.md#getsize)*
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
 **Returns:** [TileSize](../interfaces/_terminal_.tilesize.md)
 Size of the widget, measured in tiles
+
+___
+<a id="getvalueat"></a>
+
+###  getValueAt
+
+▸ **getValueAt**(column: *`number`*, line: *`number`*): `T`
+
+*Defined in [widgets/Select.ts:310](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L310)*
+
+Get the value of the option at the specified terminal position (absolute)
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| column | `number` |  column of the terminal |
+| line | `number` |  line of the terminal |
+
+**Returns:** `T`
+option value or `undefined` if not found
+
+___
+<a id="getvaluefromindex"></a>
+
+###  getValueFromIndex
+
+▸ **getValueFromIndex**(index: *`number`*): `T`
+
+*Defined in [widgets/Select.ts:165](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L165)*
+
+Get the provided value from the specified index
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| index | `number` |  index of the desired option |
+
+**Returns:** `T`
+Reference to a copy of the provided value
 
 ___
 <a id="isat"></a>
@@ -311,7 +593,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isAt](_widget_.widget.md#isat)*
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -334,7 +616,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocusable](_widget_.widget.md#isfocusable)*
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -350,7 +632,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocused](_widget_.widget.md#isfocused)*
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -358,32 +640,64 @@ Check if the widget is currently focused or not
 if the widget is focused or not.
 
 ___
-<a id="next"></a>
+<a id="isindexselected"></a>
 
-###  next
+###  isIndexSelected
 
-▸ **next**(): `boolean`
+▸ **isIndexSelected**(index: *`number`*): `boolean`
 
-*Defined in [widgets/Select.ts:263](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L263)*
+*Defined in [widgets/Select.ts:320](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L320)*
 
-Select the next option to the current one
+Check if the option with the specified index is selected or not
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| index | `number` |  index of the option to check |
 
 **Returns:** `boolean`
-`true` if the selected option has changed, `false` otherwise
+`true` if selected, `false` if not. `undefined` if the option is not found
 
 ___
-<a id="prev"></a>
+<a id="isoptionselected"></a>
 
-###  prev
+###  isOptionSelected
 
-▸ **prev**(): `boolean`
+▸ **isOptionSelected**(option: *[SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>*): `boolean`
 
-*Defined in [widgets/Select.ts:254](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L254)*
+*Defined in [widgets/Select.ts:332](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L332)*
 
-Select the previous option to the current one
+Check if an option is selected or not
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| option | [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`> |  option to check |
 
 **Returns:** `boolean`
-`true` if the selected option has changed, `false` otherwise
+`true` if selected, `false` if not. `undefined` if the option is not found
+
+___
+<a id="isvalueselected"></a>
+
+###  isValueSelected
+
+▸ **isValueSelected**(value: *`T`*): `boolean`
+
+*Defined in [widgets/Select.ts:344](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L344)*
+
+Check if the option with the specified value is selected or not
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| value | `T` |  value to check |
+
+**Returns:** `boolean`
+`true` if selected, `false` if not. `undefined` if the option is not found
 
 ___
 <a id="render"></a>
@@ -394,31 +708,11 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[render](_widget_.widget.md#render)*
 
-*Defined in [widgets/Select.ts:75](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L75)*
+*Defined in [widgets/Select.ts:108](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L108)*
 
 Render the widget in the associated terminal
 
 **Returns:** `void`
-
-___
-<a id="selectindex"></a>
-
-###  selectIndex
-
-▸ **selectIndex**(index: *`number`*): `boolean`
-
-*Defined in [widgets/Select.ts:168](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L168)*
-
-Select the option with the specified index. This will do nothing if the option is disabled or the index not found.
-
-**Parameters:**
-
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| index | `number` |  New index to set as selected (starting on 0) |
-
-**Returns:** `boolean`
-`true` if the selected option has changed, `false` otherwise
 
 ___
 <a id="selectoption"></a>
@@ -427,15 +721,15 @@ ___
 
 ▸ **selectOption**(option: *[SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`>*): `boolean`
 
-*Defined in [widgets/Select.ts:233](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L233)*
+*Defined in [widgets/Select.ts:393](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L393)*
 
-Select the specified option. This will do nothing the option is disabled or not found
+Select the first option with the specified. This will do nothing if all the options with that value are disabled
 
 **Parameters:**
 
 | Param | Type | Description |
 | ------ | ------ | ------ |
-| option | [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`> |  Explicit option to select |
+| option | [SelectOption](../interfaces/_widgets_select_.selectoption.md)<`T`> |  Value to search the option by |
 
 **Returns:** `boolean`
 `true` if the selected option has changed, `false` otherwise
@@ -447,9 +741,9 @@ ___
 
 ▸ **selectValue**(value: *`T`*): `boolean`
 
-*Defined in [widgets/Select.ts:210](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L210)*
+*Defined in [widgets/Select.ts:404](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L404)*
 
-Select the first option with the specified value. This will do nothing if all the options with that value are disabled there's no one with the specified value.
+Select the first option with the specified value. This will do nothing if all the options with that value are disabled
 
 **Parameters:**
 
@@ -469,7 +763,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[setOptions](_widget_.widget.md#setoptions)*
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -487,6 +781,27 @@ Do not reimplement this setter in any subclass, but implement `updateOptions`
 **Returns:** `void`
 
 ___
+<a id="toggleindex"></a>
+
+###  toggleIndex
+
+▸ **toggleIndex**(index: *`number`*, selected?: *`boolean`*): `boolean`
+
+*Defined in [widgets/Select.ts:362](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L362)*
+
+Select the option with the specified index. This will do nothing if the option is disabled or the index is invalid. If `options.multiple` is `false`, then it will unselect any previously selected option. The list won't focus the option and therefore, the scroll won't change.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| index | `number` |  New index to set as selected (starting on 0) |
+| `Optional` selected | `boolean` |  If \`true\` the option will be set as selected. If \`false\`, the option will be set as unselected. If \`undefined\`, the option will be negated (selected -> unselected / unselected -> selected) |
+
+**Returns:** `boolean`
+`true` if the selected option has changed, `false` otherwise
+
+___
 <a id="updateoptions"></a>
 
 ### `<Protected>` updateOptions
@@ -495,7 +810,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[updateOptions](_widget_.widget.md#updateoptions)*
 
-*Defined in [widgets/Select.ts:273](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L273)*
+*Defined in [widgets/Select.ts:493](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L493)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/classes/_widgets_text_.text.md
+++ b/docs/classes/_widgets_text_.text.md
@@ -56,7 +56,7 @@ Display formatted text in the terminal, allowing vertical scroll
 
 *Overrides [Widget](_widget_.widget.md).[constructor](_widget_.widget.md#constructor)*
 
-*Defined in [widgets/Text.ts:67](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L67)*
+*Defined in [widgets/Text.ts:67](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L67)*
 
 **Parameters:**
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[allocated](_widget_.widget.md#allocated)*
 
-*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L39)*
+*Defined in [Widget.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L39)*
 
 If the widget has been allocated or not
 
@@ -93,7 +93,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focused](_widget_.widget.md#focused)*
 
-*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L37)*
+*Defined in [Widget.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L37)*
 
 If the widget is focused or not
 
@@ -106,7 +106,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[options](_widget_.widget.md#options)*
 
-*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L35)*
+*Defined in [Widget.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L35)*
 
 Widget options
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[parent](_widget_.widget.md#parent)*
 
-*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L33)*
+*Defined in [Widget.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L33)*
 
 container of the widget, if any
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[terminal](_widget_.widget.md#terminal)*
 
-*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L31)*
+*Defined in [Widget.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L31)*
 
 Reference to the parent terminal where it should be rendered
 
@@ -145,7 +145,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[defaultOptions](_widget_.widget.md#defaultoptions)*
 
-*Defined in [widgets/Text.ts:56](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L56)*
+*Defined in [widgets/Text.ts:56](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L56)*
 
 Default options for widget instances
 
@@ -161,7 +161,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[blur](_widget_.widget.md#blur)*
 
-*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L176)*
+*Defined in [Widget.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L176)*
 
 Remove the focus from this widget. Usually done by a upper level that controls other widgets.
 
@@ -177,7 +177,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[destruct](_widget_.widget.md#destruct)*
 
-*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L61)*
+*Defined in [Widget.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L61)*
 
 Method to call when the widget is not going to be used anymore, so it can clean whatever it set in the constructor
 
@@ -192,7 +192,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[focus](_widget_.widget.md#focus)*
 
-*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L156)*
+*Defined in [Widget.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L156)*
 
 Set this Widget as focused. Usually done by a upper level that controls other widgets (so the previously focused widget is blurred)
 
@@ -208,7 +208,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getParent](_widget_.widget.md#getparent)*
 
-*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L70)*
+*Defined in [Widget.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L70)*
 
 Get the reference to the parent of the widget, if any
 
@@ -224,7 +224,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getPosition](_widget_.widget.md#getposition)*
 
-*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L118)*
+*Defined in [Widget.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L118)*
 
 Get the position of the widget, in tile coordinates
 
@@ -240,7 +240,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[getSize](_widget_.widget.md#getsize)*
 
-*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L106)*
+*Defined in [Widget.ts:106](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L106)*
 
 Get the widget size, measured in tiles
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **getTextSize**(): [TileSize](../interfaces/_terminal_.tilesize.md)
 
-*Defined in [widgets/Text.ts:144](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L144)*
+*Defined in [widgets/Text.ts:144](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L144)*
 
 Get the size of the box if the text would be fully displayed
 
@@ -270,7 +270,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isAt](_widget_.widget.md#isat)*
 
-*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L132)*
+*Defined in [Widget.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L132)*
 
 Check if the widget is (overlaps) the specified position
 
@@ -293,7 +293,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocusable](_widget_.widget.md#isfocusable)*
 
-*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L146)*
+*Defined in [Widget.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L146)*
 
 Check if this widget is focusable (when cycling over widgets)
 
@@ -309,7 +309,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[isFocused](_widget_.widget.md#isfocused)*
 
-*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L191)*
+*Defined in [Widget.ts:191](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L191)*
 
 Check if the widget is currently focused or not
 
@@ -325,7 +325,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[render](_widget_.widget.md#render)*
 
-*Defined in [widgets/Text.ts:81](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L81)*
+*Defined in [widgets/Text.ts:81](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L81)*
 
 Render the widget in the associated terminal
 
@@ -338,7 +338,7 @@ ___
 
 ▸ **scrollLines**(lines: *`number`*): `boolean`
 
-*Defined in [widgets/Text.ts:188](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L188)*
+*Defined in [widgets/Text.ts:188](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L188)*
 
 Move the starting line of the text
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **scrollPages**(pages: *`number`*): `boolean`
 
-*Defined in [widgets/Text.ts:198](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L198)*
+*Defined in [widgets/Text.ts:198](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L198)*
 
 Move the starting line of the text by pages
 
@@ -380,7 +380,7 @@ ___
 
 *Inherited from [Widget](_widget_.widget.md).[setOptions](_widget_.widget.md#setoptions)*
 
-*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L86)*
+*Defined in [Widget.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L86)*
 
 Update the options. Always use this setter so the widget knows about the change instead of changing the (protected) variable directly. The widget might do some internal calcs when this method is called.
 
@@ -404,7 +404,7 @@ ___
 
 ▸ **setScrollLine**(line: *`number`*): `boolean`
 
-*Defined in [widgets/Text.ts:157](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L157)*
+*Defined in [widgets/Text.ts:157](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L157)*
 
 Set the starting line of the text
 
@@ -426,7 +426,7 @@ ___
 
 *Overrides [Widget](_widget_.widget.md).[updateOptions](_widget_.widget.md#updateoptions)*
 
-*Defined in [widgets/Text.ts:208](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L208)*
+*Defined in [widgets/Text.ts:208](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L208)*
 
 `setOptions` will assign the options to `this.options`, but any derivated calculation should be done here.
 

--- a/docs/interfaces/_terminal_.charstyle.md
+++ b/docs/interfaces/_terminal_.charstyle.md
@@ -16,6 +16,8 @@
 
 ↳  [GridBorderOptions](_widgets_grid_.gridborderoptions.md)
 
+↳  [SelectOptionStyle](_widgets_select_.selectoptionstyle.md)
+
 ## Index
 
 ### Properties
@@ -36,7 +38,7 @@
 
 **● bg**: *`string`*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -47,7 +49,7 @@ ___
 
 **● fg**: *`string`*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -58,7 +60,7 @@ ___
 
 **● font**: *`string`*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -69,7 +71,7 @@ ___
 
 **● offsetX**: *`number`*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -80,7 +82,7 @@ ___
 
 **● offsetY**: *`number`*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 

--- a/docs/interfaces/_terminal_.decaytile.md
+++ b/docs/interfaces/_terminal_.decaytile.md
@@ -30,7 +30,7 @@
 
 **● alpha**: *`number`*
 
-*Defined in [Terminal.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L176)*
+*Defined in [Terminal.ts:176](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L176)*
 
 current opacity
 
@@ -43,7 +43,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[bg](_terminal_.charstyle.md#bg)*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [TextTile](_terminal_.texttile.md).[char](_terminal_.texttile.md#char)*
 
-*Defined in [Terminal.ts:151](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L151)*
+*Defined in [Terminal.ts:151](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L151)*
 
 char to display in the tile
 
@@ -69,7 +69,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[fg](_terminal_.charstyle.md#fg)*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[font](_terminal_.charstyle.md#font)*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -95,7 +95,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetX](_terminal_.charstyle.md#offsetx)*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -108,7 +108,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetY](_terminal_.charstyle.md#offsety)*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 

--- a/docs/interfaces/_terminal_.escapecommandparams.md
+++ b/docs/interfaces/_terminal_.escapecommandparams.md
@@ -27,7 +27,7 @@
 
 **● col**: *`number`*
 
-*Defined in [Terminal.ts:59](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L59)*
+*Defined in [Terminal.ts:59](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L59)*
 
 Column of the terminal where the matching expression starts
 
@@ -38,7 +38,7 @@ ___
 
 **● index**: *`number`*
 
-*Defined in [Terminal.ts:55](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L55)*
+*Defined in [Terminal.ts:55](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L55)*
 
 Index of the matched expression in `text`
 
@@ -49,7 +49,7 @@ ___
 
 **● line**: *`number`*
 
-*Defined in [Terminal.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L61)*
+*Defined in [Terminal.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L61)*
 
 Line of the terminal where the matching expression starts
 
@@ -60,7 +60,7 @@ ___
 
 **● match**: *`string`*
 
-*Defined in [Terminal.ts:57](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L57)*
+*Defined in [Terminal.ts:57](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L57)*
 
 Matched expression
 
@@ -71,7 +71,7 @@ ___
 
 **● terminal**: *[Terminal](../classes/_terminal_.terminal.md)*
 
-*Defined in [Terminal.ts:63](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L63)*
+*Defined in [Terminal.ts:63](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L63)*
 
 Associated terminal
 
@@ -82,7 +82,7 @@ ___
 
 **● text**: *`string`*
 
-*Defined in [Terminal.ts:53](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L53)*
+*Defined in [Terminal.ts:53](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L53)*
 
 Full text set
 

--- a/docs/interfaces/_terminal_.imagecropparams.md
+++ b/docs/interfaces/_terminal_.imagecropparams.md
@@ -25,7 +25,7 @@
 
 **● srcH**: *`number`*
 
-*Defined in [Terminal.ts:48](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L48)*
+*Defined in [Terminal.ts:48](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L48)*
 
 height (pixels) of the section to crop in the source image
 
@@ -36,7 +36,7 @@ ___
 
 **● srcW**: *`number`*
 
-*Defined in [Terminal.ts:46](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L46)*
+*Defined in [Terminal.ts:46](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L46)*
 
 width (pixels) of the section to crop in the source image
 
@@ -47,7 +47,7 @@ ___
 
 **● srcX**: *`number`*
 
-*Defined in [Terminal.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L42)*
+*Defined in [Terminal.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L42)*
 
 x-position (pixels) of the section to crop in the source image
 
@@ -58,7 +58,7 @@ ___
 
 **● srcY**: *`number`*
 
-*Defined in [Terminal.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L44)*
+*Defined in [Terminal.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L44)*
 
 y-position (pixels) of the section to crop in the source image
 

--- a/docs/interfaces/_terminal_.imageoffset.md
+++ b/docs/interfaces/_terminal_.imageoffset.md
@@ -23,7 +23,7 @@
 
 **● x**: *`number`*
 
-*Defined in [Terminal.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L28)*
+*Defined in [Terminal.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L28)*
 
 Number of pixels inside the terminal tile to offset the image horizontally
 
@@ -34,7 +34,7 @@ ___
 
 **● y**: *`number`*
 
-*Defined in [Terminal.ts:30](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L30)*
+*Defined in [Terminal.ts:30](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L30)*
 
 Number of pixels inside the terminal tile to offset the image vertically
 

--- a/docs/interfaces/_terminal_.imagesize.md
+++ b/docs/interfaces/_terminal_.imagesize.md
@@ -23,7 +23,7 @@
 
 **● height**: *`number`*
 
-*Defined in [Terminal.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L37)*
+*Defined in [Terminal.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L37)*
 
 Image height
 
@@ -34,7 +34,7 @@ ___
 
 **● width**: *`number`*
 
-*Defined in [Terminal.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L35)*
+*Defined in [Terminal.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L35)*
 
 Image width
 

--- a/docs/interfaces/_terminal_.imagetile.md
+++ b/docs/interfaces/_terminal_.imagetile.md
@@ -28,7 +28,7 @@
 
 **● crop**: *[ImageCropParams](_terminal_.imagecropparams.md)*
 
-*Defined in [Terminal.ts:164](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L164)*
+*Defined in [Terminal.ts:164](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L164)*
 
 Crop parameters for `img`
 
@@ -39,7 +39,7 @@ ___
 
 **● dstH**: *`number`*
 
-*Defined in [Terminal.ts:160](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L160)*
+*Defined in [Terminal.ts:160](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L160)*
 
 destiny height
 
@@ -50,7 +50,7 @@ ___
 
 **● dstW**: *`number`*
 
-*Defined in [Terminal.ts:158](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L158)*
+*Defined in [Terminal.ts:158](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L158)*
 
 destiny width
 
@@ -61,7 +61,7 @@ ___
 
 **● image**: *[AcceptedImage](../modules/_terminal_.md#acceptedimage)*
 
-*Defined in [Terminal.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L156)*
+*Defined in [Terminal.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L156)*
 
 image to draw
 
@@ -72,7 +72,7 @@ ___
 
 **● offset**: *[ImageOffset](_terminal_.imageoffset.md)*
 
-*Defined in [Terminal.ts:162](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L162)*
+*Defined in [Terminal.ts:162](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L162)*
 
 Offset in the destiny coordinates
 

--- a/docs/interfaces/_terminal_.internaltile.md
+++ b/docs/interfaces/_terminal_.internaltile.md
@@ -40,7 +40,7 @@
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[bg](_terminal_.charstyle.md#bg)*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -53,7 +53,7 @@ ___
 
 *Inherited from [TextTile](_terminal_.texttile.md).[char](_terminal_.texttile.md#char)*
 
-*Defined in [Terminal.ts:151](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L151)*
+*Defined in [Terminal.ts:151](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L151)*
 
 char to display in the tile
 
@@ -66,7 +66,7 @@ ___
 
 *Inherited from [ImageTile](_terminal_.imagetile.md).[crop](_terminal_.imagetile.md#crop)*
 
-*Defined in [Terminal.ts:164](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L164)*
+*Defined in [Terminal.ts:164](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L164)*
 
 Crop parameters for `img`
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [ImageTile](_terminal_.imagetile.md).[dstH](_terminal_.imagetile.md#dsth)*
 
-*Defined in [Terminal.ts:160](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L160)*
+*Defined in [Terminal.ts:160](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L160)*
 
 destiny height
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [ImageTile](_terminal_.imagetile.md).[dstW](_terminal_.imagetile.md#dstw)*
 
-*Defined in [Terminal.ts:158](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L158)*
+*Defined in [Terminal.ts:158](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L158)*
 
 destiny width
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[fg](_terminal_.charstyle.md#fg)*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -118,7 +118,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[font](_terminal_.charstyle.md#font)*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -131,7 +131,7 @@ ___
 
 *Inherited from [ImageTile](_terminal_.imagetile.md).[image](_terminal_.imagetile.md#image)*
 
-*Defined in [Terminal.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L156)*
+*Defined in [Terminal.ts:156](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L156)*
 
 image to draw
 
@@ -144,7 +144,7 @@ ___
 
 *Inherited from [ImageTile](_terminal_.imagetile.md).[offset](_terminal_.imagetile.md#offset)*
 
-*Defined in [Terminal.ts:162](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L162)*
+*Defined in [Terminal.ts:162](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L162)*
 
 Offset in the destiny coordinates
 
@@ -157,7 +157,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetX](_terminal_.charstyle.md#offsetx)*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -170,7 +170,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetY](_terminal_.charstyle.md#offsety)*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 
@@ -181,7 +181,7 @@ ___
 
 **● x**: *`number`*
 
-*Defined in [Terminal.ts:169](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L169)*
+*Defined in [Terminal.ts:169](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L169)*
 
 pre-calculated tile (not contents) x-position in pixels
 
@@ -192,7 +192,7 @@ ___
 
 **● y**: *`number`*
 
-*Defined in [Terminal.ts:171](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L171)*
+*Defined in [Terminal.ts:171](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L171)*
 
 pre-calculated tile (not contents) y-position in pixels
 

--- a/docs/interfaces/_terminal_.terminaloptions.md
+++ b/docs/interfaces/_terminal_.terminaloptions.md
@@ -47,7 +47,7 @@
 
 **● autoRender**: *`boolean`*
 
-*Defined in [Terminal.ts:126](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L126)*
+*Defined in [Terminal.ts:126](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L126)*
 
 `true` to let the terminal manage the screen changes
 
@@ -58,7 +58,7 @@ ___
 
 **● autoSize**: *`boolean`*
 
-*Defined in [Terminal.ts:128](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L128)*
+*Defined in [Terminal.ts:128](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L128)*
 
 if `true`, the containing canvas will be resized to contain the grid
 
@@ -69,7 +69,7 @@ ___
 
 **● avoidDoubleRendering**: *`boolean`*
 
-*Defined in [Terminal.ts:142](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L142)*
+*Defined in [Terminal.ts:142](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L142)*
 
 Optimization? If `true` it will check if the tile to render is already in the queue to avoid rendering it twice
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[bg](_terminal_.charstyle.md#bg)*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -93,7 +93,7 @@ ___
 
 **● clearStyle**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [Terminal.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L146)*
+*Defined in [Terminal.ts:146](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L146)*
 
 Style used when calling `clear`
 
@@ -104,7 +104,7 @@ ___
 
 **● columns**: *`number`*
 
-*Defined in [Terminal.ts:114](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L114)*
+*Defined in [Terminal.ts:114](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L114)*
 
 number of columns of the terminal, in number of tiles
 
@@ -115,7 +115,7 @@ ___
 
 **● commands**: *`object`*
 
-*Defined in [Terminal.ts:138](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L138)*
+*Defined in [Terminal.ts:138](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L138)*
 
 escape secuences to parse and their callback functions
 
@@ -130,7 +130,7 @@ ___
 
 **● cursor**: *`boolean`*
 
-*Defined in [Terminal.ts:130](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L130)*
+*Defined in [Terminal.ts:130](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L130)*
 
 `true` to show the cursor
 
@@ -141,7 +141,7 @@ ___
 
 **● cursorFrequency**: *`number`*
 
-*Defined in [Terminal.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L132)*
+*Defined in [Terminal.ts:132](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L132)*
 
 blinking frequency of the cursor. If set to `0` the blink will be disabled
 
@@ -152,7 +152,7 @@ ___
 
 **● decayInitialAlpha**: *`number`*
 
-*Defined in [Terminal.ts:136](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L136)*
+*Defined in [Terminal.ts:136](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L136)*
 
 initial opacity for the decay tile, from 0 to 1
 
@@ -163,7 +163,7 @@ ___
 
 **● decayTime**: *`number`*
 
-*Defined in [Terminal.ts:134](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L134)*
+*Defined in [Terminal.ts:134](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L134)*
 
 if > 0, milliseconds that the characters will take before disapear when changing
 
@@ -176,7 +176,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[fg](_terminal_.charstyle.md#fg)*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -189,7 +189,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[font](_terminal_.charstyle.md#font)*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -200,7 +200,7 @@ ___
 
 **● maxColumns**: *`number`*
 
-*Defined in [Terminal.ts:122](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L122)*
+*Defined in [Terminal.ts:122](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L122)*
 
 maximum number of columns (tiles) allowed
 
@@ -211,7 +211,7 @@ ___
 
 **● maxRows**: *`number`*
 
-*Defined in [Terminal.ts:124](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L124)*
+*Defined in [Terminal.ts:124](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L124)*
 
 maximum number of rows (tiles) allowed
 
@@ -222,7 +222,7 @@ ___
 
 **● minColumns**: *`number`*
 
-*Defined in [Terminal.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L118)*
+*Defined in [Terminal.ts:118](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L118)*
 
 minimum number of columns (tiles) allowed
 
@@ -233,7 +233,7 @@ ___
 
 **● minRows**: *`number`*
 
-*Defined in [Terminal.ts:120](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L120)*
+*Defined in [Terminal.ts:120](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L120)*
 
 minimum number of rows (tiles) allowed
 
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetX](_terminal_.charstyle.md#offsetx)*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -259,7 +259,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetY](_terminal_.charstyle.md#offsety)*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 
@@ -270,7 +270,7 @@ ___
 
 **● rows**: *`number`*
 
-*Defined in [Terminal.ts:116](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L116)*
+*Defined in [Terminal.ts:116](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L116)*
 
 number of rows of the terminal, in number of tiles
 
@@ -281,7 +281,7 @@ ___
 
 **● tileHeight**: *`number`*
 
-*Defined in [Terminal.ts:112](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L112)*
+*Defined in [Terminal.ts:112](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L112)*
 
 height of a tile in px
 
@@ -292,7 +292,7 @@ ___
 
 **● tileWidth**: *`number`*
 
-*Defined in [Terminal.ts:110](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L110)*
+*Defined in [Terminal.ts:110](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L110)*
 
 width of a tile in px
 
@@ -303,7 +303,7 @@ ___
 
 **● verbose**: *`boolean`*
 
-*Defined in [Terminal.ts:144](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L144)*
+*Defined in [Terminal.ts:144](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L144)*
 
 `true` to enable debug console messages options, `false` to disable them
 
@@ -314,7 +314,7 @@ ___
 
 **● viewport**: *[ViewPortOptions](_terminal_.viewportoptions.md)*
 
-*Defined in [Terminal.ts:140](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L140)*
+*Defined in [Terminal.ts:140](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L140)*
 
 Limit within the Terminal will draw
 

--- a/docs/interfaces/_terminal_.texttile.md
+++ b/docs/interfaces/_terminal_.texttile.md
@@ -35,7 +35,7 @@
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[bg](_terminal_.charstyle.md#bg)*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -46,7 +46,7 @@ ___
 
 **● char**: *`string`*
 
-*Defined in [Terminal.ts:151](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L151)*
+*Defined in [Terminal.ts:151](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L151)*
 
 char to display in the tile
 
@@ -59,7 +59,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[fg](_terminal_.charstyle.md#fg)*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[font](_terminal_.charstyle.md#font)*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetX](_terminal_.charstyle.md#offsetx)*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -98,7 +98,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetY](_terminal_.charstyle.md#offsety)*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 

--- a/docs/interfaces/_terminal_.tileposition.md
+++ b/docs/interfaces/_terminal_.tileposition.md
@@ -23,7 +23,7 @@
 
 **● col**: *`number`*
 
-*Defined in [Terminal.ts:75](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L75)*
+*Defined in [Terminal.ts:75](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L75)*
 
 x-coordinate of a tile in the grid
 
@@ -34,7 +34,7 @@ ___
 
 **● line**: *`number`*
 
-*Defined in [Terminal.ts:77](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L77)*
+*Defined in [Terminal.ts:77](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L77)*
 
 y-coordinate of a tile in the grid
 

--- a/docs/interfaces/_terminal_.tilesize.md
+++ b/docs/interfaces/_terminal_.tilesize.md
@@ -23,7 +23,7 @@
 
 **● columns**: *`number`*
 
-*Defined in [Terminal.ts:68](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L68)*
+*Defined in [Terminal.ts:68](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L68)*
 
 number of columns of the terminal, in number of tiles
 
@@ -34,7 +34,7 @@ ___
 
 **● rows**: *`number`*
 
-*Defined in [Terminal.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L70)*
+*Defined in [Terminal.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L70)*
 
 number of rows of the terminal, in number of tiles
 

--- a/docs/interfaces/_terminal_.viewportoptions.md
+++ b/docs/interfaces/_terminal_.viewportoptions.md
@@ -25,7 +25,7 @@
 
 **● bottom**: *`number`*
 
-*Defined in [Terminal.ts:103](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L103)*
+*Defined in [Terminal.ts:103](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L103)*
 
 Bottom coordinate (in tiles) of the Terminal viewport (-1 to stick always to `height`)
 
@@ -36,7 +36,7 @@ ___
 
 **● left**: *`number`*
 
-*Defined in [Terminal.ts:105](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L105)*
+*Defined in [Terminal.ts:105](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L105)*
 
 Left coordinate (in tiles) of the Terminal viewport (-1 to stick always to `0`)
 
@@ -47,7 +47,7 @@ ___
 
 **● right**: *`number`*
 
-*Defined in [Terminal.ts:101](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L101)*
+*Defined in [Terminal.ts:101](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L101)*
 
 Right coordinate (in tiles) of the Terminal viewport (-1 to stick always to `width`)
 
@@ -58,7 +58,7 @@ ___
 
 **● top**: *`number`*
 
-*Defined in [Terminal.ts:99](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L99)*
+*Defined in [Terminal.ts:99](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L99)*
 
 Top coordinate (in tiles) of the Terminal viewport (-1 to stick always to 0)
 

--- a/docs/interfaces/_terminalevent_.eventoptions.md
+++ b/docs/interfaces/_terminalevent_.eventoptions.md
@@ -23,7 +23,7 @@
 
 **● cancellable**: *`boolean`*
 
-*Defined in [TerminalEvent.ts:3](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L3)*
+*Defined in [TerminalEvent.ts:3](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L3)*
 
 ___
 <a id="type"></a>
@@ -32,7 +32,7 @@ ___
 
 **● type**: *`string`*
 
-*Defined in [TerminalEvent.ts:2](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/TerminalEvent.ts#L2)*
+*Defined in [TerminalEvent.ts:2](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/TerminalEvent.ts#L2)*
 
 ___
 

--- a/docs/interfaces/_util_requestanimationframe_.vendorwindow.md
+++ b/docs/interfaces/_util_requestanimationframe_.vendorwindow.md
@@ -242,14 +242,14 @@
 
 *Inherited from Window.Blob*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19484*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19484*
 
 #### Type declaration
 
  constructor : function
 ⊕ **new __type**(blobParts?: *`any`[]*, options?: *`BlobPropertyBag`*): `Blob`
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:7362*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:7362*
 
 **Parameters:**
 
@@ -271,14 +271,14 @@ ___
 
 *Inherited from Window.URL*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19482*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19482*
 
 #### Type declaration
 
  constructor : function
 ⊕ **new __type**(url: *`string`*, base?: * `string` &#124; `URL`*): `URL`
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:18063*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:18063*
 
 **Parameters:**
 
@@ -294,7 +294,7 @@ ___
  createObjectURL : function
 ▸ **createObjectURL**(object: *`any`*, options?: *`ObjectURLOptions`*): `string`
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:18065*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:18065*
 
 **Parameters:**
 
@@ -308,7 +308,7 @@ ___
  revokeObjectURL : function
 ▸ **revokeObjectURL**(url: *`string`*): `void`
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:18066*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:18066*
 
 **Parameters:**
 
@@ -327,14 +327,14 @@ ___
 
 *Inherited from Window.URLSearchParams*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19483*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19483*
 
 #### Type declaration
 
  constructor : function
 ⊕ **new __type**(init?: * `string` &#124; `URLSearchParams`*): `URLSearchParams`
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20170*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20170*
 
 Constructor returning a URLSearchParams object.
 
@@ -355,14 +355,14 @@ ___
 
 **● Window**: *`object`*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19528*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19528*
 
 #### Type declaration
 
  constructor : function
 ⊕ **new __type**(): `Window`
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19529*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19529*
 
 **Returns:** `Window`
 
@@ -377,7 +377,7 @@ ___
 
 *Inherited from Window.applicationCache*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19340*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19340*
 
 ___
 <a id="caches"></a>
@@ -388,7 +388,7 @@ ___
 
 *Inherited from Window.caches*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19341*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19341*
 
 ___
 <a id="clientinformation"></a>
@@ -399,7 +399,7 @@ ___
 
 *Inherited from Window.clientInformation*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19342*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19342*
 
 ___
 <a id="closed"></a>
@@ -410,7 +410,7 @@ ___
 
 *Inherited from Window.closed*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19343*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19343*
 
 ___
 <a id="console"></a>
@@ -421,7 +421,7 @@ ___
 
 *Inherited from WindowConsole.console*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20032*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20032*
 
 ___
 <a id="constructor-4"></a>
@@ -432,7 +432,7 @@ ___
 
 *Inherited from Object.constructor*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:112*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:112*
 
 The initial value of Object.prototype.constructor is the standard built-in Object constructor.
 
@@ -445,7 +445,7 @@ ___
 
 *Inherited from Window.crypto*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19344*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19344*
 
 ___
 <a id="customelements"></a>
@@ -456,7 +456,7 @@ ___
 
 *Inherited from Window.customElements*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19485*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19485*
 
 ___
 <a id="defaultstatus"></a>
@@ -467,7 +467,7 @@ ___
 
 *Inherited from Window.defaultStatus*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19345*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19345*
 
 ___
 <a id="devicepixelratio"></a>
@@ -478,7 +478,7 @@ ___
 
 *Inherited from Window.devicePixelRatio*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19346*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19346*
 
 ___
 <a id="donottrack"></a>
@@ -489,7 +489,7 @@ ___
 
 *Inherited from Window.doNotTrack*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19348*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19348*
 
 ___
 <a id="document"></a>
@@ -500,7 +500,7 @@ ___
 
 *Inherited from Window.document*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19347*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19347*
 
 ___
 <a id="event"></a>
@@ -512,7 +512,7 @@ ___
 
 *Inherited from Window.event*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19349*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19349*
 
 ___
 <a id="external"></a>
@@ -523,7 +523,7 @@ ___
 
 *Inherited from Window.external*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19350*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19350*
 
 ___
 <a id="frameelement"></a>
@@ -534,7 +534,7 @@ ___
 
 *Inherited from Window.frameElement*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19351*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19351*
 
 ___
 <a id="frames"></a>
@@ -545,7 +545,7 @@ ___
 
 *Inherited from Window.frames*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19352*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19352*
 
 ___
 <a id="history"></a>
@@ -556,7 +556,7 @@ ___
 
 *Inherited from Window.history*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19353*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19353*
 
 ___
 <a id="indexeddb"></a>
@@ -567,7 +567,7 @@ ___
 
 *Inherited from IDBEnvironment.indexedDB*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19896*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19896*
 
 ___
 <a id="innerheight"></a>
@@ -578,7 +578,7 @@ ___
 
 *Inherited from Window.innerHeight*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19354*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19354*
 
 ___
 <a id="innerwidth"></a>
@@ -589,7 +589,7 @@ ___
 
 *Inherited from Window.innerWidth*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19355*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19355*
 
 ___
 <a id="issecurecontext"></a>
@@ -600,7 +600,7 @@ ___
 
 *Inherited from Window.isSecureContext*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19356*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19356*
 
 ___
 <a id="length"></a>
@@ -611,7 +611,7 @@ ___
 
 *Inherited from Window.length*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19357*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19357*
 
 ___
 <a id="localstorage"></a>
@@ -622,7 +622,7 @@ ___
 
 *Inherited from WindowLocalStorage.localStorage*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20036*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20036*
 
 ___
 <a id="location"></a>
@@ -633,7 +633,7 @@ ___
 
 *Inherited from Window.location*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19358*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19358*
 
 ___
 <a id="locationbar"></a>
@@ -644,7 +644,7 @@ ___
 
 *Inherited from Window.locationbar*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19359*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19359*
 
 ___
 <a id="menubar"></a>
@@ -655,7 +655,7 @@ ___
 
 *Inherited from Window.menubar*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19360*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19360*
 
 ___
 <a id="mozrequestanimationframe"></a>
@@ -664,7 +664,7 @@ ___
 
 **● mozRequestAnimationFrame**: *[requestAnimationFrameFn](../modules/_util_requestanimationframe_.md#requestanimationframefn)*
 
-*Defined in [util/requestAnimationFrame.ts:4](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/requestAnimationFrame.ts#L4)*
+*Defined in [util/requestAnimationFrame.ts:4](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/requestAnimationFrame.ts#L4)*
 
 ___
 <a id="mscontentscript"></a>
@@ -675,7 +675,7 @@ ___
 
 *Inherited from Window.msContentScript*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19361*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19361*
 
 ___
 <a id="mscredentials"></a>
@@ -686,7 +686,7 @@ ___
 
 *Inherited from Window.msCredentials*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19362*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19362*
 
 ___
 <a id="msrequestanimationframe"></a>
@@ -695,7 +695,7 @@ ___
 
 **● msRequestAnimationFrame**: *[requestAnimationFrameFn](../modules/_util_requestanimationframe_.md#requestanimationframefn)*
 
-*Defined in [util/requestAnimationFrame.ts:6](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/requestAnimationFrame.ts#L6)*
+*Defined in [util/requestAnimationFrame.ts:6](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/requestAnimationFrame.ts#L6)*
 
 ___
 <a id="name"></a>
@@ -706,7 +706,7 @@ ___
 
 *Inherited from Window.name*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19363*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19363*
 
 ___
 <a id="navigator"></a>
@@ -717,7 +717,7 @@ ___
 
 *Inherited from Window.navigator*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19364*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19364*
 
 ___
 <a id="orequestanimationframe"></a>
@@ -726,7 +726,7 @@ ___
 
 **● oRequestAnimationFrame**: *[requestAnimationFrameFn](../modules/_util_requestanimationframe_.md#requestanimationframefn)*
 
-*Defined in [util/requestAnimationFrame.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/requestAnimationFrame.ts#L5)*
+*Defined in [util/requestAnimationFrame.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/requestAnimationFrame.ts#L5)*
 
 ___
 <a id="offscreenbuffering"></a>
@@ -738,7 +738,7 @@ ___
 
 *Inherited from Window.offscreenBuffering*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19365*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19365*
 
 ___
 <a id="onabort"></a>
@@ -749,7 +749,7 @@ ___
 
 *Inherited from Window.onabort*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19366*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19366*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`UIEvent`*): `any`
@@ -772,7 +772,7 @@ ___
 
 *Inherited from Window.onafterprint*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19367*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19367*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -795,7 +795,7 @@ ___
 
 *Inherited from Window.onbeforeprint*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19368*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19368*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -818,7 +818,7 @@ ___
 
 *Inherited from Window.onbeforeunload*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19369*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19369*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`BeforeUnloadEvent`*): `any`
@@ -841,7 +841,7 @@ ___
 
 *Inherited from Window.onblur*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19370*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19370*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`FocusEvent`*): `any`
@@ -864,7 +864,7 @@ ___
 
 *Inherited from Window.oncanplay*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19371*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19371*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -887,7 +887,7 @@ ___
 
 *Inherited from Window.oncanplaythrough*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19372*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19372*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -910,7 +910,7 @@ ___
 
 *Inherited from Window.onchange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19373*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19373*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -933,7 +933,7 @@ ___
 
 *Inherited from Window.onclick*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19374*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19374*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -956,7 +956,7 @@ ___
 
 *Inherited from Window.oncompassneedscalibration*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19375*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19375*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -979,7 +979,7 @@ ___
 
 *Inherited from Window.oncontextmenu*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19376*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19376*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`PointerEvent`*): `any`
@@ -1002,7 +1002,7 @@ ___
 
 *Inherited from Window.ondblclick*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19377*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19377*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1025,7 +1025,7 @@ ___
 
 *Inherited from Window.ondevicelight*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19378*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19378*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DeviceLightEvent`*): `any`
@@ -1048,7 +1048,7 @@ ___
 
 *Inherited from Window.ondevicemotion*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19379*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19379*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DeviceMotionEvent`*): `any`
@@ -1071,7 +1071,7 @@ ___
 
 *Inherited from Window.ondeviceorientation*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19380*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19380*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DeviceOrientationEvent`*): `any`
@@ -1094,7 +1094,7 @@ ___
 
 *Inherited from Window.ondrag*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19381*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19381*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1117,7 +1117,7 @@ ___
 
 *Inherited from Window.ondragend*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19382*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19382*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1140,7 +1140,7 @@ ___
 
 *Inherited from Window.ondragenter*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19383*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19383*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1163,7 +1163,7 @@ ___
 
 *Inherited from Window.ondragleave*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19384*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19384*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1186,7 +1186,7 @@ ___
 
 *Inherited from Window.ondragover*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19385*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19385*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1209,7 +1209,7 @@ ___
 
 *Inherited from Window.ondragstart*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19386*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19386*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1232,7 +1232,7 @@ ___
 
 *Inherited from Window.ondrop*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19387*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19387*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`DragEvent`*): `any`
@@ -1255,7 +1255,7 @@ ___
 
 *Inherited from Window.ondurationchange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19388*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19388*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1278,7 +1278,7 @@ ___
 
 *Inherited from Window.onemptied*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19389*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19389*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1301,7 +1301,7 @@ ___
 
 *Inherited from Window.onended*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19390*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19390*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MediaStreamErrorEvent`*): `any`
@@ -1324,7 +1324,7 @@ ___
 
 *Inherited from Window.onerror*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19391*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19391*
 
 ___
 <a id="onfocus"></a>
@@ -1335,7 +1335,7 @@ ___
 
 *Inherited from Window.onfocus*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19392*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19392*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`FocusEvent`*): `any`
@@ -1358,7 +1358,7 @@ ___
 
 *Inherited from Window.onhashchange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19393*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19393*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`HashChangeEvent`*): `any`
@@ -1381,7 +1381,7 @@ ___
 
 *Inherited from Window.oninput*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19394*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19394*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1404,7 +1404,7 @@ ___
 
 *Inherited from Window.oninvalid*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19395*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19395*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1427,7 +1427,7 @@ ___
 
 *Inherited from Window.onkeydown*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19396*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19396*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`KeyboardEvent`*): `any`
@@ -1450,7 +1450,7 @@ ___
 
 *Inherited from Window.onkeypress*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19397*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19397*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`KeyboardEvent`*): `any`
@@ -1473,7 +1473,7 @@ ___
 
 *Inherited from Window.onkeyup*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19398*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19398*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`KeyboardEvent`*): `any`
@@ -1496,7 +1496,7 @@ ___
 
 *Inherited from Window.onload*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19399*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19399*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1519,7 +1519,7 @@ ___
 
 *Inherited from Window.onloadeddata*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19400*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19400*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1542,7 +1542,7 @@ ___
 
 *Inherited from Window.onloadedmetadata*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19401*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19401*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1565,7 +1565,7 @@ ___
 
 *Inherited from Window.onloadstart*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19402*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19402*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -1588,7 +1588,7 @@ ___
 
 *Inherited from Window.onmessage*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19403*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19403*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MessageEvent`*): `any`
@@ -1611,7 +1611,7 @@ ___
 
 *Inherited from Window.onmousedown*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19404*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19404*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1634,7 +1634,7 @@ ___
 
 *Inherited from Window.onmouseenter*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19405*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19405*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1657,7 +1657,7 @@ ___
 
 *Inherited from Window.onmouseleave*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19406*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19406*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1680,7 +1680,7 @@ ___
 
 *Inherited from Window.onmousemove*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19407*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19407*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1703,7 +1703,7 @@ ___
 
 *Inherited from Window.onmouseout*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19408*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19408*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1726,7 +1726,7 @@ ___
 
 *Inherited from Window.onmouseover*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19409*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19409*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1749,7 +1749,7 @@ ___
 
 *Inherited from Window.onmouseup*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19410*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19410*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MouseEvent`*): `any`
@@ -1772,7 +1772,7 @@ ___
 
 *Inherited from Window.onmousewheel*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19411*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19411*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`WheelEvent`*): `any`
@@ -1795,7 +1795,7 @@ ___
 
 *Inherited from Window.onmsgesturechange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19412*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19412*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1818,7 +1818,7 @@ ___
 
 *Inherited from Window.onmsgesturedoubletap*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19413*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19413*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1841,7 +1841,7 @@ ___
 
 *Inherited from Window.onmsgestureend*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19414*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19414*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1864,7 +1864,7 @@ ___
 
 *Inherited from Window.onmsgesturehold*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19415*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19415*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1887,7 +1887,7 @@ ___
 
 *Inherited from Window.onmsgesturestart*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19416*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19416*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1910,7 +1910,7 @@ ___
 
 *Inherited from Window.onmsgesturetap*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19417*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19417*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1933,7 +1933,7 @@ ___
 
 *Inherited from Window.onmsinertiastart*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19418*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19418*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSGestureEvent`*): `any`
@@ -1956,7 +1956,7 @@ ___
 
 *Inherited from Window.onmspointercancel*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19419*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19419*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -1979,7 +1979,7 @@ ___
 
 *Inherited from Window.onmspointerdown*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19420*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19420*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2002,7 +2002,7 @@ ___
 
 *Inherited from Window.onmspointerenter*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19421*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19421*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2025,7 +2025,7 @@ ___
 
 *Inherited from Window.onmspointerleave*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19422*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19422*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2048,7 +2048,7 @@ ___
 
 *Inherited from Window.onmspointermove*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19423*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19423*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2071,7 +2071,7 @@ ___
 
 *Inherited from Window.onmspointerout*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19424*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19424*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2094,7 +2094,7 @@ ___
 
 *Inherited from Window.onmspointerover*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19425*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19425*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2117,7 +2117,7 @@ ___
 
 *Inherited from Window.onmspointerup*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19426*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19426*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`MSPointerEvent`*): `any`
@@ -2140,7 +2140,7 @@ ___
 
 *Inherited from Window.onoffline*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19427*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19427*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2163,7 +2163,7 @@ ___
 
 *Inherited from Window.ononline*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19428*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19428*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2186,7 +2186,7 @@ ___
 
 *Inherited from Window.onorientationchange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19429*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19429*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2209,7 +2209,7 @@ ___
 
 *Inherited from Window.onpagehide*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19430*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19430*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`PageTransitionEvent`*): `any`
@@ -2232,7 +2232,7 @@ ___
 
 *Inherited from Window.onpageshow*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19431*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19431*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`PageTransitionEvent`*): `any`
@@ -2255,7 +2255,7 @@ ___
 
 *Inherited from Window.onpause*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19432*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19432*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2278,7 +2278,7 @@ ___
 
 *Inherited from Window.onplay*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19433*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19433*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2301,7 +2301,7 @@ ___
 
 *Inherited from Window.onplaying*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19434*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19434*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2324,7 +2324,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointercancel*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19861*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19861*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2347,7 +2347,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointerdown*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19862*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19862*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2370,7 +2370,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointerenter*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19863*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19863*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2393,7 +2393,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointerleave*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19864*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19864*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2416,7 +2416,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointermove*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19865*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19865*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2439,7 +2439,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointerout*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19866*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19866*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2462,7 +2462,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointerover*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19867*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19867*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2485,7 +2485,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onpointerup*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19868*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19868*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`PointerEvent`*): `any`
@@ -2508,7 +2508,7 @@ ___
 
 *Inherited from Window.onpopstate*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19435*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19435*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`PopStateEvent`*): `any`
@@ -2531,7 +2531,7 @@ ___
 
 *Inherited from Window.onprogress*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19436*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19436*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`ProgressEvent`*): `any`
@@ -2554,7 +2554,7 @@ ___
 
 *Inherited from Window.onratechange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19437*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19437*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2577,7 +2577,7 @@ ___
 
 *Inherited from Window.onreadystatechange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19438*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19438*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`ProgressEvent`*): `any`
@@ -2600,7 +2600,7 @@ ___
 
 *Inherited from Window.onreset*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19439*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19439*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2623,7 +2623,7 @@ ___
 
 *Inherited from Window.onresize*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19440*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19440*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`UIEvent`*): `any`
@@ -2646,7 +2646,7 @@ ___
 
 *Inherited from Window.onscroll*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19441*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19441*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`UIEvent`*): `any`
@@ -2669,7 +2669,7 @@ ___
 
 *Inherited from Window.onseeked*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19442*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19442*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2692,7 +2692,7 @@ ___
 
 *Inherited from Window.onseeking*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19443*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19443*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2715,7 +2715,7 @@ ___
 
 *Inherited from Window.onselect*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19444*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19444*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`UIEvent`*): `any`
@@ -2738,7 +2738,7 @@ ___
 
 *Inherited from Window.onstalled*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19445*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19445*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2761,7 +2761,7 @@ ___
 
 *Inherited from Window.onstorage*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19446*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19446*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`StorageEvent`*): `any`
@@ -2784,7 +2784,7 @@ ___
 
 *Inherited from Window.onsubmit*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19447*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19447*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2807,7 +2807,7 @@ ___
 
 *Inherited from Window.onsuspend*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19448*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19448*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2830,7 +2830,7 @@ ___
 
 *Inherited from Window.ontimeupdate*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19449*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19449*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2853,7 +2853,7 @@ ___
 
 *Inherited from Window.ontouchcancel*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19450*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19450*
 
 #### Type declaration
 ▸(ev: *`TouchEvent`*): `any`
@@ -2875,7 +2875,7 @@ ___
 
 *Inherited from Window.ontouchend*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19451*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19451*
 
 #### Type declaration
 ▸(ev: *`TouchEvent`*): `any`
@@ -2897,7 +2897,7 @@ ___
 
 *Inherited from Window.ontouchmove*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19452*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19452*
 
 #### Type declaration
 ▸(ev: *`TouchEvent`*): `any`
@@ -2919,7 +2919,7 @@ ___
 
 *Inherited from Window.ontouchstart*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19453*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19453*
 
 #### Type declaration
 ▸(ev: *`TouchEvent`*): `any`
@@ -2941,7 +2941,7 @@ ___
 
 *Inherited from Window.onunload*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19454*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19454*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2964,7 +2964,7 @@ ___
 
 *Inherited from Window.onvolumechange*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19455*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19455*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -2987,7 +2987,7 @@ ___
 
 *Inherited from Window.onwaiting*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19456*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19456*
 
 #### Type declaration
 ▸(this: *`Window`*, ev: *`Event`*): `any`
@@ -3010,7 +3010,7 @@ ___
 
 *Inherited from GlobalEventHandlers.onwheel*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19869*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19869*
 
 #### Type declaration
 ▸(this: *`GlobalEventHandlers`*, ev: *`WheelEvent`*): `any`
@@ -3033,7 +3033,7 @@ ___
 
 *Inherited from Window.opener*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19457*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19457*
 
 ___
 <a id="orientation"></a>
@@ -3045,7 +3045,7 @@ ___
 
 *Inherited from Window.orientation*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19458*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19458*
 
 ___
 <a id="outerheight"></a>
@@ -3056,7 +3056,7 @@ ___
 
 *Inherited from Window.outerHeight*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19459*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19459*
 
 ___
 <a id="outerwidth"></a>
@@ -3067,7 +3067,7 @@ ___
 
 *Inherited from Window.outerWidth*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19460*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19460*
 
 ___
 <a id="pagexoffset"></a>
@@ -3078,7 +3078,7 @@ ___
 
 *Inherited from Window.pageXOffset*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19461*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19461*
 
 ___
 <a id="pageyoffset"></a>
@@ -3089,7 +3089,7 @@ ___
 
 *Inherited from Window.pageYOffset*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19462*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19462*
 
 ___
 <a id="parent"></a>
@@ -3100,7 +3100,7 @@ ___
 
 *Inherited from Window.parent*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19463*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19463*
 
 ___
 <a id="performance"></a>
@@ -3111,7 +3111,7 @@ ___
 
 *Inherited from Window.performance*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19464*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19464*
 
 ___
 <a id="personalbar"></a>
@@ -3122,7 +3122,7 @@ ___
 
 *Inherited from Window.personalbar*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19465*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19465*
 
 ___
 <a id="screen"></a>
@@ -3133,7 +3133,7 @@ ___
 
 *Inherited from Window.screen*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19466*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19466*
 
 ___
 <a id="screenleft"></a>
@@ -3144,7 +3144,7 @@ ___
 
 *Inherited from Window.screenLeft*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19467*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19467*
 
 ___
 <a id="screentop"></a>
@@ -3155,7 +3155,7 @@ ___
 
 *Inherited from Window.screenTop*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19468*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19468*
 
 ___
 <a id="screenx"></a>
@@ -3166,7 +3166,7 @@ ___
 
 *Inherited from Window.screenX*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19469*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19469*
 
 ___
 <a id="screeny"></a>
@@ -3177,7 +3177,7 @@ ___
 
 *Inherited from Window.screenY*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19470*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19470*
 
 ___
 <a id="scrollx"></a>
@@ -3188,7 +3188,7 @@ ___
 
 *Inherited from Window.scrollX*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19472*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19472*
 
 ___
 <a id="scrolly"></a>
@@ -3199,7 +3199,7 @@ ___
 
 *Inherited from Window.scrollY*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19473*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19473*
 
 ___
 <a id="scrollbars"></a>
@@ -3210,7 +3210,7 @@ ___
 
 *Inherited from Window.scrollbars*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19471*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19471*
 
 ___
 <a id="self"></a>
@@ -3221,7 +3221,7 @@ ___
 
 *Inherited from Window.self*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19474*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19474*
 
 ___
 <a id="sessionstorage"></a>
@@ -3232,7 +3232,7 @@ ___
 
 *Inherited from WindowSessionStorage.sessionStorage*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20040*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20040*
 
 ___
 <a id="speechsynthesis"></a>
@@ -3243,7 +3243,7 @@ ___
 
 *Inherited from Window.speechSynthesis*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19475*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19475*
 
 ___
 <a id="status"></a>
@@ -3254,7 +3254,7 @@ ___
 
 *Inherited from Window.status*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19476*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19476*
 
 ___
 <a id="statusbar"></a>
@@ -3265,7 +3265,7 @@ ___
 
 *Inherited from Window.statusbar*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19477*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19477*
 
 ___
 <a id="stylemedia"></a>
@@ -3276,7 +3276,7 @@ ___
 
 *Inherited from Window.styleMedia*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19478*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19478*
 
 ___
 <a id="toolbar"></a>
@@ -3287,7 +3287,7 @@ ___
 
 *Inherited from Window.toolbar*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19479*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19479*
 
 ___
 <a id="top"></a>
@@ -3298,7 +3298,7 @@ ___
 
 *Inherited from Window.top*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19480*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19480*
 
 ___
 <a id="window-1"></a>
@@ -3309,7 +3309,7 @@ ___
 
 *Inherited from Window.window*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19481*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19481*
 
 ___
 
@@ -3327,7 +3327,7 @@ ___
 
 *Overrides EventTarget.addEventListener*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19522*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19522*
 
 **Type parameters:**
 
@@ -3346,7 +3346,7 @@ ___
 
 *Overrides EventTarget.addEventListener*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19523*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19523*
 
 **Parameters:**
 
@@ -3367,7 +3367,7 @@ ___
 
 *Inherited from Window.alert*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19486*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19486*
 
 **Parameters:**
 
@@ -3386,7 +3386,7 @@ ___
 
 *Inherited from WindowBase64.atob*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20027*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20027*
 
 **Parameters:**
 
@@ -3405,7 +3405,7 @@ ___
 
 *Inherited from Window.blur*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19487*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19487*
 
 **Returns:** `void`
 
@@ -3418,7 +3418,7 @@ ___
 
 *Inherited from WindowBase64.btoa*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20028*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20028*
 
 **Parameters:**
 
@@ -3437,7 +3437,7 @@ ___
 
 *Inherited from Window.cancelAnimationFrame*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19488*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19488*
 
 **Parameters:**
 
@@ -3456,7 +3456,7 @@ ___
 
 *Inherited from Window.captureEvents*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19489*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19489*
 
 **Returns:** `void`
 
@@ -3469,7 +3469,7 @@ ___
 
 *Inherited from WindowTimersExtension.clearImmediate*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20053*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20053*
 
 **Parameters:**
 
@@ -3488,7 +3488,7 @@ ___
 
 *Inherited from WindowTimers.clearInterval*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20044*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20044*
 
 **Parameters:**
 
@@ -3507,7 +3507,7 @@ ___
 
 *Inherited from WindowTimers.clearTimeout*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20045*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20045*
 
 **Parameters:**
 
@@ -3526,7 +3526,7 @@ ___
 
 *Inherited from Window.close*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19490*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19490*
 
 **Returns:** `void`
 
@@ -3539,7 +3539,7 @@ ___
 
 *Inherited from Window.confirm*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19491*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19491*
 
 **Parameters:**
 
@@ -3560,7 +3560,7 @@ ___
 
 *Inherited from Window.createImageBitmap*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19517*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19517*
 
 **Parameters:**
 
@@ -3573,7 +3573,7 @@ ___
 
 *Inherited from Window.createImageBitmap*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19518*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19518*
 
 **Parameters:**
 
@@ -3597,7 +3597,7 @@ ___
 
 *Inherited from Window.departFocus*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19492*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19492*
 
 **Parameters:**
 
@@ -3617,7 +3617,7 @@ ___
 
 *Inherited from EventTarget.dispatchEvent*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:9545*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:9545*
 
 **Parameters:**
 
@@ -3636,7 +3636,7 @@ ___
 
 *Inherited from GlobalFetch.fetch*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19877*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19877*
 
 **Parameters:**
 
@@ -3656,7 +3656,7 @@ ___
 
 *Inherited from Window.focus*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19493*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19493*
 
 **Returns:** `void`
 
@@ -3669,7 +3669,7 @@ ___
 
 *Inherited from Window.getComputedStyle*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19494*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19494*
 
 **Parameters:**
 
@@ -3689,7 +3689,7 @@ ___
 
 *Inherited from Window.getMatchedCSSRules*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19495*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19495*
 
 **Parameters:**
 
@@ -3709,7 +3709,7 @@ ___
 
 *Inherited from Window.getSelection*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19496*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19496*
 
 **Returns:** `Selection`
 
@@ -3722,7 +3722,7 @@ ___
 
 *Inherited from Object.hasOwnProperty*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:127*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:127*
 
 Determines whether an object has a property with the specified name.
 
@@ -3743,7 +3743,7 @@ ___
 
 *Inherited from Object.isPrototypeOf*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:133*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:133*
 
 Determines whether an object exists in another object's prototype chain.
 
@@ -3764,7 +3764,7 @@ ___
 
 *Inherited from Window.matchMedia*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19497*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19497*
 
 **Parameters:**
 
@@ -3783,7 +3783,7 @@ ___
 
 *Inherited from Window.moveBy*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19498*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19498*
 
 **Parameters:**
 
@@ -3803,7 +3803,7 @@ ___
 
 *Inherited from Window.moveTo*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19499*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19499*
 
 **Parameters:**
 
@@ -3823,7 +3823,7 @@ ___
 
 *Inherited from Window.msWriteProfilerMark*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19500*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19500*
 
 **Parameters:**
 
@@ -3842,7 +3842,7 @@ ___
 
 *Inherited from Window.open*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19501*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19501*
 
 **Parameters:**
 
@@ -3864,7 +3864,7 @@ ___
 
 *Inherited from Window.postMessage*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19502*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19502*
 
 **Parameters:**
 
@@ -3885,7 +3885,7 @@ ___
 
 *Inherited from Window.print*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19503*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19503*
 
 **Returns:** `void`
 
@@ -3898,7 +3898,7 @@ ___
 
 *Inherited from Window.prompt*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19504*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19504*
 
 **Parameters:**
 
@@ -3918,7 +3918,7 @@ ___
 
 *Inherited from Object.propertyIsEnumerable*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:139*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:139*
 
 Determines whether a specified property is enumerable.
 
@@ -3939,7 +3939,7 @@ ___
 
 *Inherited from Window.releaseEvents*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19505*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19505*
 
 **Returns:** `void`
 
@@ -3956,7 +3956,7 @@ ___
 
 *Overrides EventTarget.removeEventListener*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19524*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19524*
 
 **Type parameters:**
 
@@ -3975,7 +3975,7 @@ ___
 
 *Overrides EventTarget.removeEventListener*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19525*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19525*
 
 **Parameters:**
 
@@ -3996,7 +3996,7 @@ ___
 
 *Inherited from Window.requestAnimationFrame*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19506*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19506*
 
 **Parameters:**
 
@@ -4015,7 +4015,7 @@ ___
 
 *Inherited from Window.resizeBy*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19507*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19507*
 
 **Parameters:**
 
@@ -4035,7 +4035,7 @@ ___
 
 *Inherited from Window.resizeTo*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19508*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19508*
 
 **Parameters:**
 
@@ -4057,7 +4057,7 @@ ___
 
 *Inherited from Window.scroll*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19509*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19509*
 
 **Parameters:**
 
@@ -4070,7 +4070,7 @@ ___
 
 *Inherited from Window.scroll*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19519*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19519*
 
 **Parameters:**
 
@@ -4091,7 +4091,7 @@ ___
 
 *Inherited from Window.scrollBy*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19510*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19510*
 
 **Parameters:**
 
@@ -4104,7 +4104,7 @@ ___
 
 *Inherited from Window.scrollBy*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19521*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19521*
 
 **Parameters:**
 
@@ -4125,7 +4125,7 @@ ___
 
 *Inherited from Window.scrollTo*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19511*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19511*
 
 **Parameters:**
 
@@ -4138,7 +4138,7 @@ ___
 
 *Inherited from Window.scrollTo*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19520*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19520*
 
 **Parameters:**
 
@@ -4159,7 +4159,7 @@ ___
 
 *Inherited from WindowTimersExtension.setImmediate*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20054*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20054*
 
 **Parameters:**
 
@@ -4171,7 +4171,7 @@ ___
 
 *Inherited from WindowTimersExtension.setImmediate*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20055*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20055*
 
 **Parameters:**
 
@@ -4193,7 +4193,7 @@ ___
 
 *Inherited from WindowTimers.setInterval*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20046*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20046*
 
 **Parameters:**
 
@@ -4206,7 +4206,7 @@ ___
 
 *Inherited from WindowTimers.setInterval*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20047*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20047*
 
 **Parameters:**
 
@@ -4229,7 +4229,7 @@ ___
 
 *Inherited from WindowTimers.setTimeout*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20048*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20048*
 
 **Parameters:**
 
@@ -4242,7 +4242,7 @@ ___
 
 *Inherited from WindowTimers.setTimeout*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20049*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:20049*
 
 **Parameters:**
 
@@ -4263,7 +4263,7 @@ ___
 
 *Inherited from Window.stop*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19512*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19512*
 
 **Returns:** `void`
 
@@ -4276,7 +4276,7 @@ ___
 
 *Inherited from Object.toLocaleString*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:118*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:118*
 
 Returns a date converted to a string using the current locale.
 
@@ -4291,7 +4291,7 @@ ___
 
 *Inherited from Object.toString*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:115*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:115*
 
 Returns a string representation of an object.
 
@@ -4306,7 +4306,7 @@ ___
 
 *Inherited from Object.valueOf*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:121*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:121*
 
 Returns the primitive value of the specified object.
 
@@ -4321,7 +4321,7 @@ ___
 
 *Inherited from Window.webkitCancelAnimationFrame*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19513*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19513*
 
 **Parameters:**
 
@@ -4340,7 +4340,7 @@ ___
 
 *Inherited from Window.webkitConvertPointFromNodeToPage*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19514*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19514*
 
 **Parameters:**
 
@@ -4360,7 +4360,7 @@ ___
 
 *Inherited from Window.webkitConvertPointFromPageToNode*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19515*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19515*
 
 **Parameters:**
 
@@ -4380,7 +4380,7 @@ ___
 
 *Inherited from Window.webkitRequestAnimationFrame*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19516*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:19516*
 
 **Parameters:**
 

--- a/docs/interfaces/_util_tokenizer_.texttoken.md
+++ b/docs/interfaces/_util_tokenizer_.texttoken.md
@@ -24,7 +24,7 @@
 
 **● index**: *`number`*
 
-*Defined in [util/tokenizer.ts:7](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L7)*
+*Defined in [util/tokenizer.ts:7](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L7)*
 
 Index of the string where it starts
 
@@ -35,7 +35,7 @@ ___
 
 **● isSeparator**: *`boolean`*
 
-*Defined in [util/tokenizer.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L5)*
+*Defined in [util/tokenizer.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L5)*
 
 If the matched text is a separator or not. It should alternate between true/false
 
@@ -46,7 +46,7 @@ ___
 
 **● text**: *`string`*
 
-*Defined in [util/tokenizer.ts:3](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L3)*
+*Defined in [util/tokenizer.ts:3](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L3)*
 
 Matched text. It shouldn't contain non-renderizable characters
 

--- a/docs/interfaces/_widget_.widgetoptions.md
+++ b/docs/interfaces/_widget_.widgetoptions.md
@@ -39,7 +39,7 @@
 
 **● col**: *`number`*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
@@ -50,7 +50,7 @@ ___
 
 **● focusable**: *`boolean`*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -61,7 +61,7 @@ ___
 
 **● height**: *`number`*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -72,7 +72,7 @@ ___
 
 **● line**: *`number`*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -83,7 +83,7 @@ ___
 
 **● tabIndex**: *`number`*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -94,7 +94,7 @@ ___
 
 **● width**: *`number`*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 

--- a/docs/interfaces/_widgetcontainer_.bidirectionaliterator.md
+++ b/docs/interfaces/_widgetcontainer_.bidirectionaliterator.md
@@ -36,7 +36,7 @@ Extended Iterator interface that will return a `next` and a `prev` methods.
 
 *Overrides Iterator.next*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:4798*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:4798*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 ▸ **prev**(): `IteratorResult`<`T`>
 
-*Defined in [WidgetContainer.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L8)*
+*Defined in [WidgetContainer.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L8)*
 
 **Returns:** `IteratorResult`<`T`>
 
@@ -66,7 +66,7 @@ ___
 
 *Inherited from Iterator.return*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:4799*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:4799*
 
 **Parameters:**
 
@@ -83,7 +83,7 @@ ___
 
 ▸ **seek**(value?: * `T` &#124; `number`*): `void`
 
-*Defined in [WidgetContainer.ts:9](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L9)*
+*Defined in [WidgetContainer.ts:9](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L9)*
 
 **Parameters:**
 
@@ -102,7 +102,7 @@ ___
 
 *Inherited from Iterator.throw*
 
-*Defined in /Users/daniel.berlanga/Dev/other/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:4800*
+*Defined in C:/dev/others/terminal-in-canvas/node_modules/typedoc/node_modules/typescript/lib/lib.es6.d.ts:4800*
 
 **Parameters:**
 

--- a/docs/interfaces/_widgetcontainer_.widgetcontainer.md
+++ b/docs/interfaces/_widgetcontainer_.widgetcontainer.md
@@ -34,7 +34,7 @@ A Widget that can contain other Widgets should implement several common methods 
 
 ▸ **__@iterator**(startWidget?: * [Widget](../classes/_widget_.widget.md) &#124; `number`*): [BidirectionalIterator](_widgetcontainer_.bidirectionaliterator.md)<[Widget](../classes/_widget_.widget.md)>
 
-*Defined in [WidgetContainer.ts:83](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L83)*
+*Defined in [WidgetContainer.ts:83](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L83)*
 
 Get a bidirectional iterator to move across the attached widgets of the container
 *__example__*: // Given the items \[A, B, C, D\] of the WidgetContainer w it = wSymbol.iterator; it.next(); // A it.next(); // B it.next(); // C it.prev(); // B it.next(); // C it.next(); // D it.next(); // null
@@ -66,7 +66,7 @@ ___
 
 ▸ **attachWidget**<`WidgetClass`>(...args: *`any`[]*): `WidgetClass`
 
-*Defined in [WidgetContainer.ts:30](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L30)*
+*Defined in [WidgetContainer.ts:30](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L30)*
 
 Attach a Widget to the container. The parameters depends on each container
 
@@ -89,7 +89,7 @@ ___
 
 ▸ **dettachWidget**(widget: *[Widget](../classes/_widget_.widget.md)*): `boolean`
 
-*Defined in [WidgetContainer.ts:38](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L38)*
+*Defined in [WidgetContainer.ts:38](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L38)*
 
 Dettach a widget from the container
 
@@ -109,7 +109,7 @@ ___
 
 ▸ **getParent**(): [WidgetContainer](_widgetcontainer_.widgetcontainer.md)
 
-*Defined in [WidgetContainer.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L22)*
+*Defined in [WidgetContainer.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L22)*
 
 Get the reference to the parent of the widget, if any
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **getWidgetAt**(column: *`number`*, line: *`number`*): [Widget](../classes/_widget_.widget.md)
 
-*Defined in [WidgetContainer.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L47)*
+*Defined in [WidgetContainer.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L47)*
 
 Get a previously attached widget by its position
 

--- a/docs/interfaces/_widgets_box_.boxaspectoptions.md
+++ b/docs/interfaces/_widgets_box_.boxaspectoptions.md
@@ -23,7 +23,7 @@
 
 **● boxBorders**: *[BoxBorderOptions](_widgets_box_.boxborderoptions.md)*
 
-*Defined in [widgets/Box.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L47)*
+*Defined in [widgets/Box.ts:47](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L47)*
 
 Options related to the border of the box
 
@@ -34,7 +34,7 @@ ___
 
 **● boxTitle**: *[BoxTitleOptions](_widgets_box_.boxtitleoptions.md)*
 
-*Defined in [widgets/Box.ts:45](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L45)*
+*Defined in [widgets/Box.ts:45](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L45)*
 
 Options related to the title, if used
 

--- a/docs/interfaces/_widgets_box_.boxborderoptions.md
+++ b/docs/interfaces/_widgets_box_.boxborderoptions.md
@@ -39,7 +39,7 @@
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[bg](_terminal_.charstyle.md#bg)*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -50,7 +50,7 @@ ___
 
 **● bottom**: *`string`*
 
-*Defined in [widgets/Box.ts:19](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L19)*
+*Defined in [widgets/Box.ts:19](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L19)*
 
 ___
 <a id="bottomleft"></a>
@@ -59,7 +59,7 @@ ___
 
 **● bottomLeft**: *`string`*
 
-*Defined in [widgets/Box.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L18)*
+*Defined in [widgets/Box.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L18)*
 
 ___
 <a id="bottomright"></a>
@@ -68,7 +68,7 @@ ___
 
 **● bottomRight**: *`string`*
 
-*Defined in [widgets/Box.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L20)*
+*Defined in [widgets/Box.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L20)*
 
 ___
 <a id="center"></a>
@@ -77,7 +77,7 @@ ___
 
 **● center**: *`string`*
 
-*Defined in [widgets/Box.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L16)*
+*Defined in [widgets/Box.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L16)*
 
 ___
 <a id="fg"></a>
@@ -88,7 +88,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[fg](_terminal_.charstyle.md#fg)*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[font](_terminal_.charstyle.md#font)*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -112,7 +112,7 @@ ___
 
 **● left**: *`string`*
 
-*Defined in [widgets/Box.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L15)*
+*Defined in [widgets/Box.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L15)*
 
 ___
 <a id="offsetx"></a>
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetX](_terminal_.charstyle.md#offsetx)*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetY](_terminal_.charstyle.md#offsety)*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 
@@ -147,7 +147,7 @@ ___
 
 **● right**: *`string`*
 
-*Defined in [widgets/Box.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L17)*
+*Defined in [widgets/Box.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L17)*
 
 ___
 <a id="top"></a>
@@ -156,7 +156,7 @@ ___
 
 **● top**: *`string`*
 
-*Defined in [widgets/Box.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L13)*
+*Defined in [widgets/Box.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L13)*
 
 ___
 <a id="topleft"></a>
@@ -165,7 +165,7 @@ ___
 
 **● topLeft**: *`string`*
 
-*Defined in [widgets/Box.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L12)*
+*Defined in [widgets/Box.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L12)*
 
 ___
 <a id="topright"></a>
@@ -174,7 +174,7 @@ ___
 
 **● topRight**: *`string`*
 
-*Defined in [widgets/Box.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L14)*
+*Defined in [widgets/Box.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L14)*
 
 ___
 

--- a/docs/interfaces/_widgets_box_.boxoptions.md
+++ b/docs/interfaces/_widgets_box_.boxoptions.md
@@ -34,7 +34,7 @@
 
 **● base**: *[BoxAspectOptions](_widgets_box_.boxaspectoptions.md)*
 
-*Defined in [widgets/Box.ts:56](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L56)*
+*Defined in [widgets/Box.ts:56](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L56)*
 
 Options used when the widget is focuseable but not focused
 
@@ -47,7 +47,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[col](_widget_.widgetoptions.md#col)*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
@@ -58,7 +58,7 @@ ___
 
 **● disabled**: *[BoxAspectOptions](_widgets_box_.boxaspectoptions.md)*
 
-*Defined in [widgets/Box.ts:60](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L60)*
+*Defined in [widgets/Box.ts:60](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L60)*
 
 Options used when the widget is not focuseable
 
@@ -69,7 +69,7 @@ ___
 
 **● focus**: *[BoxAspectOptions](_widgets_box_.boxaspectoptions.md)*
 
-*Defined in [widgets/Box.ts:58](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L58)*
+*Defined in [widgets/Box.ts:58](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L58)*
 
 Options used when the widget is focused
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[focusable](_widget_.widgetoptions.md#focusable)*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -95,7 +95,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[height](_widget_.widgetoptions.md#height)*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -108,7 +108,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[line](_widget_.widgetoptions.md#line)*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -119,7 +119,7 @@ ___
 
 **● padding**: *[BoxPaddingOptions](_widgets_box_.boxpaddingoptions.md)*
 
-*Defined in [widgets/Box.ts:54](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L54)*
+*Defined in [widgets/Box.ts:54](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L54)*
 
 Number of blank tiles to leave between the border and the attached widget
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[tabIndex](_widget_.widgetoptions.md#tabindex)*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -143,7 +143,7 @@ ___
 
 **● title**: *`string`*
 
-*Defined in [widgets/Box.ts:52](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L52)*
+*Defined in [widgets/Box.ts:52](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L52)*
 
 Title to display at the top of the box
 
@@ -156,7 +156,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[width](_widget_.widgetoptions.md#width)*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 

--- a/docs/interfaces/_widgets_box_.boxpaddingoptions.md
+++ b/docs/interfaces/_widgets_box_.boxpaddingoptions.md
@@ -25,7 +25,7 @@
 
 **● bottom**: *`number`*
 
-*Defined in [widgets/Box.ts:38](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L38)*
+*Defined in [widgets/Box.ts:38](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L38)*
 
 Number of blank tiles to leave between the bottom border and the attached widget
 
@@ -36,7 +36,7 @@ ___
 
 **● left**: *`number`*
 
-*Defined in [widgets/Box.ts:40](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L40)*
+*Defined in [widgets/Box.ts:40](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L40)*
 
 Number of blank tiles to leave between the left border and the attached widget
 
@@ -47,7 +47,7 @@ ___
 
 **● right**: *`number`*
 
-*Defined in [widgets/Box.ts:36](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L36)*
+*Defined in [widgets/Box.ts:36](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L36)*
 
 Number of blank tiles to leave between the right border and the attached widget
 
@@ -58,7 +58,7 @@ ___
 
 **● top**: *`number`*
 
-*Defined in [widgets/Box.ts:34](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L34)*
+*Defined in [widgets/Box.ts:34](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L34)*
 
 Number of blank tiles to leave between the top border and the attached widget
 

--- a/docs/interfaces/_widgets_box_.boxpooltiles.md
+++ b/docs/interfaces/_widgets_box_.boxpooltiles.md
@@ -31,7 +31,7 @@
 
 **● bottom**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:72](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L72)*
+*Defined in [widgets/Box.ts:72](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L72)*
 
 ___
 <a id="bottomleft"></a>
@@ -40,7 +40,7 @@ ___
 
 **● bottomLeft**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:71](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L71)*
+*Defined in [widgets/Box.ts:71](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L71)*
 
 ___
 <a id="bottomright"></a>
@@ -49,7 +49,7 @@ ___
 
 **● bottomRight**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:73](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L73)*
+*Defined in [widgets/Box.ts:73](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L73)*
 
 ___
 <a id="center"></a>
@@ -58,7 +58,7 @@ ___
 
 **● center**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:69](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L69)*
+*Defined in [widgets/Box.ts:69](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L69)*
 
 ___
 <a id="left"></a>
@@ -67,7 +67,7 @@ ___
 
 **● left**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:68](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L68)*
+*Defined in [widgets/Box.ts:68](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L68)*
 
 ___
 <a id="right"></a>
@@ -76,7 +76,7 @@ ___
 
 **● right**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L70)*
+*Defined in [widgets/Box.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L70)*
 
 ___
 <a id="title"></a>
@@ -85,7 +85,7 @@ ___
 
 **● title**: *[TextTile](_terminal_.texttile.md)[]*
 
-*Defined in [widgets/Box.ts:64](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L64)*
+*Defined in [widgets/Box.ts:64](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L64)*
 
 ___
 <a id="top"></a>
@@ -94,7 +94,7 @@ ___
 
 **● top**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:66](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L66)*
+*Defined in [widgets/Box.ts:66](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L66)*
 
 ___
 <a id="topleft"></a>
@@ -103,7 +103,7 @@ ___
 
 **● topLeft**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:65](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L65)*
+*Defined in [widgets/Box.ts:65](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L65)*
 
 ___
 <a id="topright"></a>
@@ -112,7 +112,7 @@ ___
 
 **● topRight**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/Box.ts:67](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Box.ts#L67)*
+*Defined in [widgets/Box.ts:67](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L67)*
 
 ___
 

--- a/docs/interfaces/_widgets_grid_.attachedwidget.md
+++ b/docs/interfaces/_widgets_grid_.attachedwidget.md
@@ -26,7 +26,7 @@
 
 **● col**: *`number`*
 
-*Defined in [widgets/Grid.ts:51](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L51)*
+*Defined in [widgets/Grid.ts:51](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L51)*
 
 x-position in grid columns
 
@@ -37,7 +37,7 @@ ___
 
 **● height**: *`number`*
 
-*Defined in [widgets/Grid.ts:57](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L57)*
+*Defined in [widgets/Grid.ts:57](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L57)*
 
 height in grid rows
 
@@ -48,7 +48,7 @@ ___
 
 **● line**: *`number`*
 
-*Defined in [widgets/Grid.ts:53](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L53)*
+*Defined in [widgets/Grid.ts:53](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L53)*
 
 y-position in grid rows
 
@@ -59,7 +59,7 @@ ___
 
 **● widget**: *[Widget](../classes/_widget_.widget.md)*
 
-*Defined in [widgets/Grid.ts:49](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L49)*
+*Defined in [widgets/Grid.ts:49](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L49)*
 
 widget instance
 
@@ -70,7 +70,7 @@ ___
 
 **● width**: *`number`*
 
-*Defined in [widgets/Grid.ts:55](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L55)*
+*Defined in [widgets/Grid.ts:55](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L55)*
 
 width in grid columns
 

--- a/docs/interfaces/_widgets_grid_.gridborderoptions.md
+++ b/docs/interfaces/_widgets_grid_.gridborderoptions.md
@@ -43,7 +43,7 @@
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[bg](_terminal_.charstyle.md#bg)*
 
-*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L94)*
+*Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
 
@@ -54,7 +54,7 @@ ___
 
 **● bottom**: *`string`*
 
-*Defined in [widgets/Grid.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L31)*
+*Defined in [widgets/Grid.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L31)*
 
 ___
 <a id="bottomleft"></a>
@@ -63,7 +63,7 @@ ___
 
 **● bottomLeft**: *`string`*
 
-*Defined in [widgets/Grid.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L37)*
+*Defined in [widgets/Grid.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L37)*
 
 ___
 <a id="bottomright"></a>
@@ -72,7 +72,7 @@ ___
 
 **● bottomRight**: *`string`*
 
-*Defined in [widgets/Grid.ts:36](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L36)*
+*Defined in [widgets/Grid.ts:36](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L36)*
 
 ___
 <a id="cross"></a>
@@ -81,7 +81,7 @@ ___
 
 **● cross**: *`string`*
 
-*Defined in [widgets/Grid.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L44)*
+*Defined in [widgets/Grid.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L44)*
 
 ___
 <a id="fg"></a>
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[fg](_terminal_.charstyle.md#fg)*
 
-*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L92)*
+*Defined in [Terminal.ts:92](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L92)*
 
 foreground color (i.e. `#00ff00`)
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[font](_terminal_.charstyle.md#font)*
 
-*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L86)*
+*Defined in [Terminal.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L86)*
 
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
@@ -116,7 +116,7 @@ ___
 
 **● left**: *`string`*
 
-*Defined in [widgets/Grid.ts:32](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L32)*
+*Defined in [widgets/Grid.ts:32](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L32)*
 
 ___
 <a id="nobottom"></a>
@@ -125,7 +125,7 @@ ___
 
 **● noBottom**: *`string`*
 
-*Defined in [widgets/Grid.ts:41](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L41)*
+*Defined in [widgets/Grid.ts:41](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L41)*
 
 ___
 <a id="noleft"></a>
@@ -134,7 +134,7 @@ ___
 
 **● noLeft**: *`string`*
 
-*Defined in [widgets/Grid.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L42)*
+*Defined in [widgets/Grid.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L42)*
 
 ___
 <a id="noright"></a>
@@ -143,7 +143,7 @@ ___
 
 **● noRight**: *`string`*
 
-*Defined in [widgets/Grid.ts:40](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L40)*
+*Defined in [widgets/Grid.ts:40](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L40)*
 
 ___
 <a id="notop"></a>
@@ -152,7 +152,7 @@ ___
 
 **● noTop**: *`string`*
 
-*Defined in [widgets/Grid.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L39)*
+*Defined in [widgets/Grid.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L39)*
 
 ___
 <a id="offsetx"></a>
@@ -163,7 +163,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetX](_terminal_.charstyle.md#offsetx)*
 
-*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L88)*
+*Defined in [Terminal.ts:88](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L88)*
 
 x-offset to apply to each character inside the tile
 
@@ -176,7 +176,7 @@ ___
 
 *Inherited from [CharStyle](_terminal_.charstyle.md).[offsetY](_terminal_.charstyle.md#offsety)*
 
-*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L90)*
+*Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
 
@@ -187,7 +187,7 @@ ___
 
 **● right**: *`string`*
 
-*Defined in [widgets/Grid.ts:30](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L30)*
+*Defined in [widgets/Grid.ts:30](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L30)*
 
 ___
 <a id="top"></a>
@@ -196,7 +196,7 @@ ___
 
 **● top**: *`string`*
 
-*Defined in [widgets/Grid.ts:29](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L29)*
+*Defined in [widgets/Grid.ts:29](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L29)*
 
 ___
 <a id="topleft"></a>
@@ -205,7 +205,7 @@ ___
 
 **● topLeft**: *`string`*
 
-*Defined in [widgets/Grid.ts:34](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L34)*
+*Defined in [widgets/Grid.ts:34](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L34)*
 
 ___
 <a id="topright"></a>
@@ -214,7 +214,7 @@ ___
 
 **● topRight**: *`string`*
 
-*Defined in [widgets/Grid.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L35)*
+*Defined in [widgets/Grid.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L35)*
 
 ___
 

--- a/docs/interfaces/_widgets_grid_.gridoptions.md
+++ b/docs/interfaces/_widgets_grid_.gridoptions.md
@@ -38,7 +38,7 @@
 
 **● borderStyle**: *[GridBorderOptions](_widgets_grid_.gridborderoptions.md)*
 
-*Defined in [widgets/Grid.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L17)*
+*Defined in [widgets/Grid.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L17)*
 
 Style to use for the border when enabled
 
@@ -49,7 +49,7 @@ ___
 
 **● borders**: *`boolean`*
 
-*Defined in [widgets/Grid.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L15)*
+*Defined in [widgets/Grid.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L15)*
 
 Borders enabled (`true`) or disabled (`false`). Disabled by default
 
@@ -62,7 +62,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[col](_widget_.widgetoptions.md#col)*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
@@ -73,7 +73,7 @@ ___
 
 **● columns**: *`number`*
 
-*Defined in [widgets/Grid.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L11)*
+*Defined in [widgets/Grid.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L11)*
 
 Number of columns of the grid
 
@@ -86,7 +86,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[focusable](_widget_.widgetoptions.md#focusable)*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -97,7 +97,7 @@ ___
 
 **● fullSize**: *`boolean`*
 
-*Defined in [widgets/Grid.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L13)*
+*Defined in [widgets/Grid.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L13)*
 
 Expand (or not) to the full size of the terminal (only applies when the parent is the terminal)
 
@@ -110,7 +110,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[height](_widget_.widgetoptions.md#height)*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[line](_widget_.widgetoptions.md#line)*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -134,7 +134,7 @@ ___
 
 **● rows**: *`number`*
 
-*Defined in [widgets/Grid.ts:9](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L9)*
+*Defined in [widgets/Grid.ts:9](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L9)*
 
 Number of rows of the grid
 
@@ -147,7 +147,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[tabIndex](_widget_.widgetoptions.md#tabindex)*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -160,7 +160,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[width](_widget_.widgetoptions.md#width)*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 
@@ -174,7 +174,7 @@ ___
 
 ▸ **calculateGridSpace**(available: *`number`*, cells: *`number`*, isRow: *`boolean`*, terminal: *[Terminal](../classes/_terminal_.terminal.md)*): `number`[]
 
-*Defined in [widgets/Grid.ts:24](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L24)*
+*Defined in [widgets/Grid.ts:24](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L24)*
 
 Function used to calculate the space for each grid Leave `undefined` to use the default one
 

--- a/docs/interfaces/_widgets_grid_.tilelist.md
+++ b/docs/interfaces/_widgets_grid_.tilelist.md
@@ -24,7 +24,7 @@
 
 **● col**: *`number`*
 
-*Defined in [widgets/Grid.ts:62](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L62)*
+*Defined in [widgets/Grid.ts:62](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L62)*
 
 ___
 <a id="line"></a>
@@ -33,7 +33,7 @@ ___
 
 **● line**: *`number`*
 
-*Defined in [widgets/Grid.ts:63](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L63)*
+*Defined in [widgets/Grid.ts:63](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L63)*
 
 ___
 <a id="tiles"></a>
@@ -42,7 +42,7 @@ ___
 
 **● tiles**: *[TextTile](_terminal_.texttile.md)[]*
 
-*Defined in [widgets/Grid.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L61)*
+*Defined in [widgets/Grid.ts:61](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L61)*
 
 ___
 

--- a/docs/interfaces/_widgets_input_.inputoptions.md
+++ b/docs/interfaces/_widgets_input_.inputoptions.md
@@ -34,7 +34,7 @@
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[col](_widget_.widgetoptions.md#col)*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
@@ -47,7 +47,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[focusable](_widget_.widgetoptions.md#focusable)*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -60,7 +60,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[height](_widget_.widgetoptions.md#height)*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -73,7 +73,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[line](_widget_.widgetoptions.md#line)*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -84,7 +84,7 @@ ___
 
 **● maxLength**: *`number`*
 
-*Defined in [widgets/Input.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L14)*
+*Defined in [widgets/Input.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L14)*
 
 If `> 0`, only will allow the specified number of characters
 
@@ -95,7 +95,7 @@ ___
 
 **● password**: *`boolean`*
 
-*Defined in [widgets/Input.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L10)*
+*Defined in [widgets/Input.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L10)*
 
 If `true`, it won't display the real value but `passwordCharacter`
 
@@ -106,7 +106,7 @@ ___
 
 **● passwordCharacter**: *`string`*
 
-*Defined in [widgets/Input.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Input.ts#L12)*
+*Defined in [widgets/Input.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Input.ts#L12)*
 
 If `password` is `true`, it will display this character instead of the real value
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[tabIndex](_widget_.widgetoptions.md#tabindex)*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[width](_widget_.widgetoptions.md#width)*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 

--- a/docs/interfaces/_widgets_progressbar_.progressbaroptions.md
+++ b/docs/interfaces/_widgets_progressbar_.progressbaroptions.md
@@ -38,7 +38,7 @@
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[col](_widget_.widgetoptions.md#col)*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
@@ -49,7 +49,7 @@ ___
 
 **● completedStyle**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/ProgressBar.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L15)*
+*Defined in [widgets/ProgressBar.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L15)*
 
 Style to use for the completed part of the bar
 
@@ -60,7 +60,7 @@ ___
 
 **● currentStyle**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/ProgressBar.ts:19](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L19)*
+*Defined in [widgets/ProgressBar.ts:19](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L19)*
 
 Style to use for current point of the bar. If not specified will be replaced by treated as a completed part
 
@@ -72,7 +72,7 @@ ___
 **● direction**: * "horizontal" &#124; "vertical"
 *
 
-*Defined in [widgets/ProgressBar.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L11)*
+*Defined in [widgets/ProgressBar.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L11)*
 
 Direction of the progress bar
 
@@ -83,7 +83,7 @@ ___
 
 **● endStyle**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/ProgressBar.ts:23](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L23)*
+*Defined in [widgets/ProgressBar.ts:23](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L23)*
 
 Style to use for the end point of the bar (as a border)
 
@@ -96,7 +96,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[focusable](_widget_.widgetoptions.md#focusable)*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[height](_widget_.widgetoptions.md#height)*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -122,7 +122,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[line](_widget_.widgetoptions.md#line)*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -133,7 +133,7 @@ ___
 
 **● pendingStyle**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/ProgressBar.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L17)*
+*Defined in [widgets/ProgressBar.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L17)*
 
 Style to use for the pending part of the bar
 
@@ -144,7 +144,7 @@ ___
 
 **● progress**: *`number`*
 
-*Defined in [widgets/ProgressBar.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L13)*
+*Defined in [widgets/ProgressBar.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L13)*
 
 Progress to display (0-1)
 
@@ -155,7 +155,7 @@ ___
 
 **● startStyle**: *[TextTile](_terminal_.texttile.md)*
 
-*Defined in [widgets/ProgressBar.ts:21](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/ProgressBar.ts#L21)*
+*Defined in [widgets/ProgressBar.ts:21](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/ProgressBar.ts#L21)*
 
 Style to use for the start point of the bar (as a border)
 
@@ -168,7 +168,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[tabIndex](_widget_.widgetoptions.md#tabindex)*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -181,7 +181,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[width](_widget_.widgetoptions.md#width)*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 

--- a/docs/interfaces/_widgets_select_.internaloption.md
+++ b/docs/interfaces/_widgets_select_.internaloption.md
@@ -1,0 +1,80 @@
+[terminal-in-canvas](../README.md) > ["widgets/Select"](../modules/_widgets_select_.md) > [InternalOption](../interfaces/_widgets_select_.internaloption.md)
+
+# Interface: InternalOption
+
+## Type parameters
+#### T 
+## Hierarchy
+
+**InternalOption**
+
+## Index
+
+### Properties
+
+* [endLine](_widgets_select_.internaloption.md#endline)
+* [option](_widgets_select_.internaloption.md#option)
+* [processedText](_widgets_select_.internaloption.md#processedtext)
+* [selected](_widgets_select_.internaloption.md#selected)
+* [startLine](_widgets_select_.internaloption.md#startline)
+
+---
+
+## Properties
+
+<a id="endline"></a>
+
+###  endLine
+
+**● endLine**: *`number`*
+
+*Defined in [widgets/Select.ts:76](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L76)*
+
+Line where the next option should start (start + processedText.length)
+
+___
+<a id="option"></a>
+
+###  option
+
+**● option**: *[SelectOption](_widgets_select_.selectoption.md)<`T`>*
+
+*Defined in [widgets/Select.ts:68](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L68)*
+
+Copy of the provided option
+
+___
+<a id="processedtext"></a>
+
+###  processedText
+
+**● processedText**: *`string`[]*
+
+*Defined in [widgets/Select.ts:72](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L72)*
+
+Preprocessed text to draw (one string per line)
+
+___
+<a id="selected"></a>
+
+###  selected
+
+**● selected**: *`boolean`*
+
+*Defined in [widgets/Select.ts:70](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L70)*
+
+Will be true if selected
+
+___
+<a id="startline"></a>
+
+###  startLine
+
+**● startLine**: *`number`*
+
+*Defined in [widgets/Select.ts:74](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L74)*
+
+Line where this option should start (accumulated number of lines of the previous options)
+
+___
+

--- a/docs/interfaces/_widgets_select_.selectoption.md
+++ b/docs/interfaces/_widgets_select_.selectoption.md
@@ -26,7 +26,7 @@
 
 **● disabled**: *`boolean`*
 
-*Defined in [widgets/Select.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L17)*
+*Defined in [widgets/Select.ts:19](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L19)*
 
 If `true`, the option won't be selectable
 
@@ -37,7 +37,7 @@ ___
 
 **● text**: *`string`*
 
-*Defined in [widgets/Select.ts:13](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L13)*
+*Defined in [widgets/Select.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L15)*
 
 Displayed text of the option
 
@@ -48,7 +48,7 @@ ___
 
 **● value**: *`T`*
 
-*Defined in [widgets/Select.ts:15](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L15)*
+*Defined in [widgets/Select.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L17)*
 
 Value of the option. Will be available when selected
 

--- a/docs/interfaces/_widgets_select_.selectoptions.md
+++ b/docs/interfaces/_widgets_select_.selectoptions.md
@@ -15,16 +15,19 @@
 ### Properties
 
 * [allowUnselect](_widgets_select_.selectoptions.md#allowunselect)
-* [base](_widgets_select_.selectoptions.md#base)
+* [baseFocusedStyle](_widgets_select_.selectoptions.md#basefocusedstyle)
+* [baseStyle](_widgets_select_.selectoptions.md#basestyle)
 * [col](_widgets_select_.selectoptions.md#col)
-* [disabled](_widgets_select_.selectoptions.md#disabled)
+* [disabledSelectedStyle](_widgets_select_.selectoptions.md#disabledselectedstyle)
+* [disabledStyle](_widgets_select_.selectoptions.md#disabledstyle)
 * [focusable](_widgets_select_.selectoptions.md#focusable)
 * [height](_widgets_select_.selectoptions.md#height)
 * [line](_widgets_select_.selectoptions.md#line)
 * [loop](_widgets_select_.selectoptions.md#loop)
+* [multiple](_widgets_select_.selectoptions.md#multiple)
 * [options](_widgets_select_.selectoptions.md#options)
-* [selected](_widgets_select_.selectoptions.md#selected)
-* [selectedIndex](_widgets_select_.selectoptions.md#selectedindex)
+* [selectedFocusedStyle](_widgets_select_.selectoptions.md#selectedfocusedstyle)
+* [selectedStyle](_widgets_select_.selectoptions.md#selectedstyle)
 * [tabIndex](_widgets_select_.selectoptions.md#tabindex)
 * [tokenizer](_widgets_select_.selectoptions.md#tokenizer)
 * [width](_widgets_select_.selectoptions.md#width)
@@ -39,18 +42,29 @@
 
 **● allowUnselect**: *`boolean`*
 
-*Defined in [widgets/Select.ts:28](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L28)*
+*Defined in [widgets/Select.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L37)*
 
 If `true`, will unselect any selected option if try to select a non-existing one
 
 ___
-<a id="base"></a>
+<a id="basefocusedstyle"></a>
 
-### `<Optional>` base
+### `<Optional>` baseFocusedStyle
 
-**● base**: *[CharStyle](_terminal_.charstyle.md)*
+**● baseFocusedStyle**: *[SelectOptionStyle](_widgets_select_.selectoptionstyle.md)*
 
-*Defined in [widgets/Select.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L35)*
+*Defined in [widgets/Select.ts:42](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L42)*
+
+Character Style for base options when focused
+
+___
+<a id="basestyle"></a>
+
+### `<Optional>` baseStyle
+
+**● baseStyle**: *[SelectOptionStyle](_widgets_select_.selectoptionstyle.md)*
+
+*Defined in [widgets/Select.ts:40](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L40)*
 
 Character Style for base options
 
@@ -63,18 +77,29 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[col](_widget_.widgetoptions.md#col)*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
 ___
-<a id="disabled"></a>
+<a id="disabledselectedstyle"></a>
 
-### `<Optional>` disabled
+### `<Optional>` disabledSelectedStyle
 
-**● disabled**: *[CharStyle](_terminal_.charstyle.md)*
+**● disabledSelectedStyle**: *[SelectOptionStyle](_widgets_select_.selectoptionstyle.md)*
 
-*Defined in [widgets/Select.ts:39](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L39)*
+*Defined in [widgets/Select.ts:50](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L50)*
+
+Character Style for disabled options when selected
+
+___
+<a id="disabledstyle"></a>
+
+### `<Optional>` disabledStyle
+
+**● disabledStyle**: *[SelectOptionStyle](_widgets_select_.selectoptionstyle.md)*
+
+*Defined in [widgets/Select.ts:48](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L48)*
 
 Character Style for disabled options
 
@@ -87,7 +112,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[focusable](_widget_.widgetoptions.md#focusable)*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -100,7 +125,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[height](_widget_.widgetoptions.md#height)*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -113,7 +138,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[line](_widget_.widgetoptions.md#line)*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -124,9 +149,20 @@ ___
 
 **● loop**: *`boolean`*
 
-*Defined in [widgets/Select.ts:24](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L24)*
+*Defined in [widgets/Select.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L33)*
 
 If `true`, the first option will be highlighted after the last one, and viceversa
+
+___
+<a id="multiple"></a>
+
+### `<Optional>` multiple
+
+**● multiple**: *`boolean`*
+
+*Defined in [widgets/Select.ts:35](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L35)*
+
+When `false`, it will be only one option selected at most
 
 ___
 <a id="options"></a>
@@ -135,31 +171,31 @@ ___
 
 **● options**: *`Array`<[SelectOption](_widgets_select_.selectoption.md)<`T`>>*
 
-*Defined in [widgets/Select.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L22)*
+*Defined in [widgets/Select.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L31)*
 
 List of options, in order, to display. Editing this value (via `setOptions` will reset the selected one)
 
 ___
-<a id="selected"></a>
+<a id="selectedfocusedstyle"></a>
 
-### `<Optional>` selected
+### `<Optional>` selectedFocusedStyle
 
-**● selected**: *[CharStyle](_terminal_.charstyle.md)*
+**● selectedFocusedStyle**: *[SelectOptionStyle](_widgets_select_.selectoptionstyle.md)*
 
-*Defined in [widgets/Select.ts:37](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L37)*
+*Defined in [widgets/Select.ts:46](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L46)*
 
-Character Style for selected options
+Character Style for selected options when focused
 
 ___
-<a id="selectedindex"></a>
+<a id="selectedstyle"></a>
 
-### `<Optional>` selectedIndex
+### `<Optional>` selectedStyle
 
-**● selectedIndex**: *`number`*
+**● selectedStyle**: *[SelectOptionStyle](_widgets_select_.selectoptionstyle.md)*
 
-*Defined in [widgets/Select.ts:26](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L26)*
+*Defined in [widgets/Select.ts:44](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L44)*
 
-Selected option index by default
+Character Style for selected options
 
 ___
 <a id="tabindex"></a>
@@ -170,7 +206,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[tabIndex](_widget_.widgetoptions.md#tabindex)*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -181,7 +217,7 @@ ___
 
 **● tokenizer**: *[TokenizerFunction](../modules/_util_tokenizer_.md#tokenizerfunction)*
 
-*Defined in [widgets/Select.ts:33](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L33)*
+*Defined in [widgets/Select.ts:56](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L56)*
 
 How to split the text (for new lines, etc.) A custom TokenizerFunction can be provided. Leave undefined to use the default one
 
@@ -194,7 +230,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[width](_widget_.widgetoptions.md#width)*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 

--- a/docs/interfaces/_widgets_select_.selectoptionstyle.md
+++ b/docs/interfaces/_widgets_select_.selectoptionstyle.md
@@ -1,25 +1,24 @@
-[terminal-in-canvas](../README.md) > ["widgets/Box"](../modules/_widgets_box_.md) > [BoxTitleOptions](../interfaces/_widgets_box_.boxtitleoptions.md)
+[terminal-in-canvas](../README.md) > ["widgets/Select"](../modules/_widgets_select_.md) > [SelectOptionStyle](../interfaces/_widgets_select_.selectoptionstyle.md)
 
-# Interface: BoxTitleOptions
+# Interface: SelectOptionStyle
 
 ## Hierarchy
 
  [CharStyle](_terminal_.charstyle.md)
 
-**↳ BoxTitleOptions**
+**↳ SelectOptionStyle**
 
 ## Index
 
 ### Properties
 
-* [bg](_widgets_box_.boxtitleoptions.md#bg)
-* [ellipsis](_widgets_box_.boxtitleoptions.md#ellipsis)
-* [fg](_widgets_box_.boxtitleoptions.md#fg)
-* [font](_widgets_box_.boxtitleoptions.md#font)
-* [marginLeft](_widgets_box_.boxtitleoptions.md#marginleft)
-* [marginRight](_widgets_box_.boxtitleoptions.md#marginright)
-* [offsetX](_widgets_box_.boxtitleoptions.md#offsetx)
-* [offsetY](_widgets_box_.boxtitleoptions.md#offsety)
+* [bg](_widgets_select_.selectoptionstyle.md#bg)
+* [fg](_widgets_select_.selectoptionstyle.md#fg)
+* [font](_widgets_select_.selectoptionstyle.md#font)
+* [offsetX](_widgets_select_.selectoptionstyle.md#offsetx)
+* [offsetY](_widgets_select_.selectoptionstyle.md#offsety)
+* [prefix](_widgets_select_.selectoptionstyle.md#prefix)
+* [suffix](_widgets_select_.selectoptionstyle.md#suffix)
 
 ---
 
@@ -36,17 +35,6 @@
 *Defined in [Terminal.ts:94](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L94)*
 
 background color (i.e. `#000000`)
-
-___
-<a id="ellipsis"></a>
-
-### `<Optional>` ellipsis
-
-**● ellipsis**: *`string`*
-
-*Defined in [widgets/Box.ts:29](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L29)*
-
-String to use when the title doesn't fit in the box
 
 ___
 <a id="fg"></a>
@@ -75,28 +63,6 @@ ___
 font or font-family to use in the terminal The format is in this order: \[style\] \[variant\] \[weight\] \[family\]
 
 ___
-<a id="marginleft"></a>
-
-### `<Optional>` marginLeft
-
-**● marginLeft**: *`number`*
-
-*Defined in [widgets/Box.ts:25](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L25)*
-
-Number of border tiles to leave to the left of the title
-
-___
-<a id="marginright"></a>
-
-### `<Optional>` marginRight
-
-**● marginRight**: *`number`*
-
-*Defined in [widgets/Box.ts:27](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Box.ts#L27)*
-
-Number of border tiles to leave to the right of the title
-
-___
 <a id="offsetx"></a>
 
 ### `<Optional>` offsetX
@@ -121,6 +87,28 @@ ___
 *Defined in [Terminal.ts:90](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L90)*
 
 y-offset to apply to each character inside the tile
+
+___
+<a id="prefix"></a>
+
+### `<Optional>` prefix
+
+**● prefix**: *`string`*
+
+*Defined in [widgets/Select.ts:24](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L24)*
+
+Text to add to the option at the beginning
+
+___
+<a id="suffix"></a>
+
+### `<Optional>` suffix
+
+**● suffix**: *`string`*
+
+*Defined in [widgets/Select.ts:26](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L26)*
+
+Text to add to the option at the end
 
 ___
 

--- a/docs/interfaces/_widgets_text_.textoptions.md
+++ b/docs/interfaces/_widgets_text_.textoptions.md
@@ -39,7 +39,7 @@
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[col](_widget_.widgetoptions.md#col)*
 
-*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L10)*
+*Defined in [Widget.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L10)*
 
 x-position of the widget in terminal tiles
 
@@ -50,7 +50,7 @@ ___
 
 **● ellipsis**: *`string`*
 
-*Defined in [widgets/Text.ts:26](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L26)*
+*Defined in [widgets/Text.ts:26](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L26)*
 
 If `tokenizer` is `false`, the `ellipsis` text will be appended when the text is too long
 
@@ -61,7 +61,7 @@ ___
 
 **● fitPageEnd**: *`boolean`*
 
-*Defined in [widgets/Text.ts:38](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L38)*
+*Defined in [widgets/Text.ts:38](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L38)*
 
 If `true`, it won't allow empty lines at the end of a page and the text will end at the last line of the widget. Set to `false` to allow empty lines (so the first line is the right next one to the last of the previous page)
 
@@ -74,7 +74,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[focusable](_widget_.widgetoptions.md#focusable)*
 
-*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L18)*
+*Defined in [Widget.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L18)*
 
 if `true`, the widget can be selectable
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[height](_widget_.widgetoptions.md#height)*
 
-*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L16)*
+*Defined in [Widget.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L16)*
 
 widget height in terminal tiles
 
@@ -100,7 +100,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[line](_widget_.widgetoptions.md#line)*
 
-*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L12)*
+*Defined in [Widget.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L12)*
 
 y-position of the widget in terminal tiles
 
@@ -111,7 +111,7 @@ ___
 
 **● persistentTypewritter**: *`boolean`*
 
-*Defined in [widgets/Text.ts:48](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L48)*
+*Defined in [widgets/Text.ts:48](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L48)*
 
 Set to `false` to apply the typewritter to the text again when it appears even if it was shown already before
 
@@ -122,7 +122,7 @@ ___
 
 **● skip**: *`number`*
 
-*Defined in [widgets/Text.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L31)*
+*Defined in [widgets/Text.ts:31](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L31)*
 
 Number of characters to skip. Useful to create a horizontal text scrolling effect
 
@@ -135,7 +135,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[tabIndex](_widget_.widgetoptions.md#tabindex)*
 
-*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L20)*
+*Defined in [Widget.ts:20](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L20)*
 
 value use for ordering the selection order with the keys
 
@@ -146,7 +146,7 @@ ___
 
 **● text**: *`string`*
 
-*Defined in [widgets/Text.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L12)*
+*Defined in [widgets/Text.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L12)*
 
 Text to display
 
@@ -157,7 +157,7 @@ ___
 
 **● textStyle**: *[CharStyle](_terminal_.charstyle.md)*
 
-*Defined in [widgets/Text.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L17)*
+*Defined in [widgets/Text.ts:17](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L17)*
 
 Basic style of the text Further styles can be applied with the `commands` option of the Terminal
 
@@ -168,7 +168,7 @@ ___
 
 **● tokenizer**: *[TokenizerFunction](../modules/_util_tokenizer_.md#tokenizerfunction)*
 
-*Defined in [widgets/Text.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L22)*
+*Defined in [widgets/Text.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L22)*
 
 How to split the text (for new lines, etc.) If `undefined` or `null`, the text will not be splitted (no-wrap)
 
@@ -179,7 +179,7 @@ ___
 
 **● typewritterDelay**: *`number`*
 
-*Defined in [widgets/Text.ts:43](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Text.ts#L43)*
+*Defined in [widgets/Text.ts:43](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Text.ts#L43)*
 
 Ms. to wait between each character when writting new text Set to `0` (default) to disable it
 
@@ -192,7 +192,7 @@ ___
 
 *Inherited from [WidgetOptions](_widget_.widgetoptions.md).[width](_widget_.widgetoptions.md#width)*
 
-*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L14)*
+*Defined in [Widget.ts:14](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L14)*
 
 widget width in terminal tiles
 

--- a/docs/modules/_eventmanager_.md
+++ b/docs/modules/_eventmanager_.md
@@ -22,7 +22,7 @@
 
 **Ƭ EventListener**: *`function`*
 
-*Defined in [EventManager.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/EventManager.ts#L5)*
+*Defined in [EventManager.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/EventManager.ts#L5)*
 
 #### Type declaration
 ▸(event: *[TerminalEvent](../classes/_terminalevent_.terminalevent.md)*, target: * [Terminal](../classes/_terminal_.terminal.md) &#124; [Widget](../classes/_widget_.widget.md)*): `void`

--- a/docs/modules/_terminal_.md
+++ b/docs/modules/_terminal_.md
@@ -41,7 +41,7 @@
 **Ƭ AcceptedImage**: * `HTMLImageElement` &#124; `HTMLCanvasElement`
 *
 
-*Defined in [Terminal.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L16)*
+*Defined in [Terminal.ts:16](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L16)*
 
 ___
 <a id="escapecallback"></a>
@@ -50,7 +50,7 @@ ___
 
 **Ƭ EscapeCallback**: *`function`*
 
-*Defined in [Terminal.ts:24](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L24)*
+*Defined in [Terminal.ts:24](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L24)*
 
 Function called when the matching command is found
 *__param__*: The whole text
@@ -77,7 +77,7 @@ ___
 
 **Ƭ IterateTileCallback**: *`function`*
 
-*Defined in [Terminal.ts:179](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Terminal.ts#L179)*
+*Defined in [Terminal.ts:179](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Terminal.ts#L179)*
 
 #### Type declaration
 ▸(tile: *[InternalTile](../interfaces/_terminal_.internaltile.md)*, i: *`number`*): `void`

--- a/docs/modules/_util_assigncharstyle_.md
+++ b/docs/modules/_util_assigncharstyle_.md
@@ -18,7 +18,7 @@
 
 ▸ **assignCharStyle**(target: *[CharStyle](../interfaces/_terminal_.charstyle.md)*, source: *[CharStyle](../interfaces/_terminal_.charstyle.md)*): [CharStyle](../interfaces/_terminal_.charstyle.md)
 
-*Defined in [util/assignCharStyle.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/assignCharStyle.ts#L11)*
+*Defined in [util/assignCharStyle.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/assignCharStyle.ts#L11)*
 
 Copy the `CharStyle` properties of `source` into `target`. Properties will be copied only if defined, and others will be ignored as well
 

--- a/docs/modules/_util_clamp_.md
+++ b/docs/modules/_util_clamp_.md
@@ -18,7 +18,7 @@
 
 ▸ **clamp**(x: *`number`*, min: *`number`*, max: *`number`*): `number`
 
-*Defined in [util/clamp.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/clamp.ts#L8)*
+*Defined in [util/clamp.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/clamp.ts#L8)*
 
 Clamp a number between two values
 

--- a/docs/modules/_util_coalesce_.md
+++ b/docs/modules/_util_coalesce_.md
@@ -18,7 +18,7 @@
 
 ▸ **coalesce**(...args: *`any`[]*): `any`
 
-*Defined in [util/coalesce.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/coalesce.ts#L8)*
+*Defined in [util/coalesce.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/coalesce.ts#L8)*
 
 Find the first not undefined/null value of the parameter list
 

--- a/docs/modules/_util_deepassign_.md
+++ b/docs/modules/_util_deepassign_.md
@@ -18,7 +18,7 @@
 
 ▸ **deepAssign**(...args: *`any`[]*): `any`
 
-*Defined in [util/deepAssign.ts:7](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/deepAssign.ts#L7)*
+*Defined in [util/deepAssign.ts:7](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/deepAssign.ts#L7)*
 
 Deep assign an object
 

--- a/docs/modules/_util_deepassignanddiff_.md
+++ b/docs/modules/_util_deepassignanddiff_.md
@@ -18,7 +18,7 @@
 
 ▸ **deepAssignAndDiff**(...args: *`any`[]*): `object`
 
-*Defined in [util/deepAssignAndDiff.ts:6](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/deepAssignAndDiff.ts#L6)*
+*Defined in [util/deepAssignAndDiff.ts:6](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/deepAssignAndDiff.ts#L6)*
 
 Deep assign an object and return just the difference (`{}` if nothing changed)
 

--- a/docs/modules/_util_emptyarray_.md
+++ b/docs/modules/_util_emptyarray_.md
@@ -18,7 +18,7 @@
 
 ▸ **emptyArray**<`T`>(arr: *`T`[]*): `T`[]
 
-*Defined in [util/emptyArray.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/emptyArray.ts#L8)*
+*Defined in [util/emptyArray.ts:8](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/emptyArray.ts#L8)*
 
 Empty an array without having to reassign it with `arr = []`. It's faster and preserves the same object pointer
 

--- a/docs/modules/_util_requestanimationframe_.md
+++ b/docs/modules/_util_requestanimationframe_.md
@@ -30,7 +30,7 @@
 
 **Ƭ requestAnimationFrameFn**: *`function`*
 
-*Defined in [util/requestAnimationFrame.ts:1](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/requestAnimationFrame.ts#L1)*
+*Defined in [util/requestAnimationFrame.ts:1](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/requestAnimationFrame.ts#L1)*
 
 #### Type declaration
 ▸(callback: *`FrameRequestCallback`*): `number`
@@ -58,7 +58,7 @@ ___
   (window as VendorWindow).msRequestAnimationFrame.bind(window) ||
   customRequestAnimationFrame
 
-*Defined in [util/requestAnimationFrame.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/requestAnimationFrame.ts#L22)*
+*Defined in [util/requestAnimationFrame.ts:22](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/requestAnimationFrame.ts#L22)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 ▸ **customRequestAnimationFrame**(callback: *`FrameRequestCallback`*): `number`
 
-*Defined in [util/requestAnimationFrame.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/requestAnimationFrame.ts#L12)*
+*Defined in [util/requestAnimationFrame.ts:12](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/requestAnimationFrame.ts#L12)*
 
 Polyfill for `window.requestAnimationFrame`
 

--- a/docs/modules/_util_tokenizer_.md
+++ b/docs/modules/_util_tokenizer_.md
@@ -28,7 +28,7 @@
 
 **Ƭ TokenizerFunction**: *`function`*
 
-*Defined in [util/tokenizer.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L10)*
+*Defined in [util/tokenizer.ts:10](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L10)*
 
 #### Type declaration
 ▸(text: *`string`*): [TextToken](../interfaces/_util_tokenizer_.texttoken.md)[]
@@ -51,7 +51,7 @@ ___
 
 ▸ **noWrap**(text: *`string`*, lineWidth: *`number`*, ellipsis?: *`string`*): `string`
 
-*Defined in [util/tokenizer.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L86)*
+*Defined in [util/tokenizer.ts:86](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L86)*
 
 Limit a text to a length, and add a ellipsis character if needed (and specified)
 
@@ -72,7 +72,7 @@ ___
 
 ▸ **splitText**(text: *`string`*, lineWidth: *`number`*, tknzr?: *[TokenizerFunction](_util_tokenizer_.md#tokenizerfunction)*): `string`[]
 
-*Defined in [util/tokenizer.ts:43](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L43)*
+*Defined in [util/tokenizer.ts:43](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L43)*
 
 Splits a text into different lines given a limit width
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **tokenizer**(text: *`string`*): [TextToken](../interfaces/_util_tokenizer_.texttoken.md)[]
 
-*Defined in [util/tokenizer.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/util/tokenizer.ts#L18)*
+*Defined in [util/tokenizer.ts:18](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/util/tokenizer.ts#L18)*
 
 Given a text, it will split it into words
 

--- a/docs/modules/_widget_.md
+++ b/docs/modules/_widget_.md
@@ -26,7 +26,7 @@
 
 **Ƭ WidgetConstructor**: *`object`*
 
-*Defined in [Widget.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/Widget.ts#L5)*
+*Defined in [Widget.ts:5](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/Widget.ts#L5)*
 
 #### Type declaration
 

--- a/docs/modules/_widgetcontainer_.md
+++ b/docs/modules/_widgetcontainer_.md
@@ -23,7 +23,7 @@
 
 ▸ **isWidgetContainer**(object: *`any`*): `boolean`
 
-*Defined in [WidgetContainer.ts:93](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/WidgetContainer.ts#L93)*
+*Defined in [WidgetContainer.ts:93](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/WidgetContainer.ts#L93)*
 
 Check if an object implements the `WidgetContainer` interface
 

--- a/docs/modules/_widgets_grid_.md
+++ b/docs/modules/_widgets_grid_.md
@@ -29,7 +29,7 @@
 
 ▸ **calculateGridSpace**(available: *`number`*, cells: *`number`*): `number`[]
 
-*Defined in [widgets/Grid.ts:585](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Grid.ts#L585)*
+*Defined in [widgets/Grid.ts:585](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Grid.ts#L585)*
 
 Function that calculates the space of each grid the most equitative way. Some cells can be bigger than others in no specific order, but with only 1 unit of difference as most.
 

--- a/docs/modules/_widgets_select_.md
+++ b/docs/modules/_widgets_select_.md
@@ -10,24 +10,45 @@
 
 ### Interfaces
 
+* [InternalOption](../interfaces/_widgets_select_.internaloption.md)
 * [SelectOption](../interfaces/_widgets_select_.selectoption.md)
+* [SelectOptionStyle](../interfaces/_widgets_select_.selectoptionstyle.md)
 * [SelectOptions](../interfaces/_widgets_select_.selectoptions.md)
+
+### Type aliases
+
+* [StyleStates](_widgets_select_.md#stylestates)
 
 ### Variables
 
-* [UNSELECTED_INDEX](_widgets_select_.md#unselected_index)
+* [SELECT_INDEX_NONE](_widgets_select_.md#select_index_none)
 
 ---
 
+## Type aliases
+
+<a id="stylestates"></a>
+
+###  StyleStates
+
+**Ƭ StyleStates**: * "baseStyle" &#124; "baseFocusedStyle" &#124; "selectedStyle" &#124; "selectedFocusedStyle" &#124; "disabledStyle" &#124; "disabledSelectedStyle"
+*
+
+*Defined in [widgets/Select.ts:59](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L59)*
+
+___
+
 ## Variables
 
-<a id="unselected_index"></a>
+<a id="select_index_none"></a>
 
-### `<Const>` UNSELECTED_INDEX
+### `<Const>` SELECT_INDEX_NONE
 
-**● UNSELECTED_INDEX**: *`-1`* =  -1
+**● SELECT_INDEX_NONE**: *`-1`* =  -1
 
-*Defined in [widgets/Select.ts:9](https://github.com/danikaze/terminal-in-canvas/blob/ad1033f/src/widgets/Select.ts#L9)*
+*Defined in [widgets/Select.ts:11](https://github.com/danikaze/terminal-in-canvas/blob/bacbdf6/src/widgets/Select.ts#L11)*
+
+Value used for an option index when no option is selected or found
 
 ___
 

--- a/examples/settings/select.ts
+++ b/examples/settings/select.ts
@@ -72,17 +72,17 @@ const pageSettingsLayout: SettingsLayout = {
               contents: [
                 new SettingButton({
                   text: '↓',
-                  callback: () => { selectWidget.next(); },
+                  callback: () => { selectWidget.focusNext(); },
                 }),
                 ' ',
                 new SettingButton({
                   text: '↑',
-                  callback: () => { selectWidget.prev(); },
+                  callback: () => { selectWidget.focusPrev(); },
                 }),
                 ' ',
                 new SettingButton({
                   text: 'Unselect',
-                  callback: () => { selectWidget.selectIndex(-1); },
+                  callback: () => { selectWidget.toggleIndex(-1); },
                 }),
               ],
             },

--- a/examples/settings/select.ts
+++ b/examples/settings/select.ts
@@ -112,6 +112,22 @@ const selectSettingsSection: SettingsSection = {
         },
       ],
     },
+    {
+      cols: [
+        {
+          title: 'Selected prefix',
+          contents: [
+            new SettingText({ name: 'selectedPrefix'}),
+          ],
+        },
+        {
+          title: 'Unselected prefix',
+          contents: [
+            new SettingText({ name: 'unselectedPrefix'}),
+          ],
+        },
+      ],
+    },
   ],
 };
 
@@ -236,6 +252,7 @@ function addSelectOption(): void {
   selectOptionsSettingRows.push(newRow);
   widgetSettingsLayout.sections[1].rows = [
     widgetSettingsLayout.sections[1].rows[0],
+    widgetSettingsLayout.sections[1].rows[1],
     ...selectOptionsSettingRows,
   ];
   widgetSettings.setSections(widgetSettingsLayout.sections);
@@ -349,7 +366,7 @@ function createPageSettings(): WidgetSettings {
 function preUpdateWidgeSettings(): boolean {
   updatePageSettings(pageSettings);
 
-  return true;
+  return false;
 }
 
 const widgetInitialSettings = {

--- a/examples/widgets/select.ts
+++ b/examples/widgets/select.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-magic-numbers */
 import { Terminal } from '../../src/Terminal';
 import { Box } from '../../src/widgets/Box';
-import { Select } from '../../src/widgets/Select';
+import { Select, SelectOptions } from '../../src/widgets/Select';
 
 import { load, LoadData } from '../util/load';
 
@@ -10,13 +10,19 @@ function enableInteraction(selects: Array<Select<number>>, terminal: Terminal, c
     if (event.key === 'ArrowUp') {
       selects.forEach((select) => {
         if (select.isFocused()) {
-          select.prev();
+          select.focusPrev();
         }
       });
     } else if (event.key === 'ArrowDown') {
       selects.forEach((select) => {
         if (select.isFocused()) {
-          select.next();
+          select.focusNext();
+        }
+      });
+    } else if (event.key === ' ') {
+      selects.forEach((select) => {
+        if (select.isFocused()) {
+          select.toggleIndex(select.getFocusedIndex());
         }
       });
     }
@@ -26,8 +32,7 @@ function enableInteraction(selects: Array<Select<number>>, terminal: Terminal, c
     const cell = terminal.getTilePosition(event.offsetX, event.offsetY);
     const widget = terminal.getLeafWidgetAt(cell.col, cell.line);
     if (widget instanceof Select) {
-      const option = widget.getOptionAt(cell.col, cell.line);
-      widget.selectOption(option);
+      widget.focusIndex(widget.getIndexAt(cell.col, cell.line));
     }
   });
 }
@@ -47,9 +52,10 @@ function run({ terminal, canvas }: LoadData): void {
 
   const s1 = terminal.attachWidget(Box, {
     ...boxOptions,
-    title: '[Select-A]',
+    title: '[S1] no loop',
     col: 1,
     line: 1,
+    loop: false,
   })
   .attachWidget<Select<number>>(Select, {
     options: [
@@ -57,40 +63,53 @@ function run({ terminal, canvas }: LoadData): void {
       { text: 'Option 2 (disabled)', value: 2, disabled: true },
       { text: 'Option 3', value: 3 },
     ],
-  });
+  } as SelectOptions<number>);
 
   const s2 = terminal.attachWidget(Box, {
     ...boxOptions,
-    title: '[Select-B]',
+    title: '[S2] custom styles',
     col: 1,
     line: 7,
   })
   .attachWidget<Select<number>>(Select, {
+    baseStyle: { fg: '#9999ff', bg: '#000000', prefix: '  ' },
+    baseFocusedStyle: { fg: '#ddddff', bg: '#000000', prefix: '> ' },
+    selectedStyle: { fg: '#9999ff', bg: '#000033', prefix: ' [', suffix: ']' },
+    selectedFocusedStyle: { fg: '#ddddff', bg: '#000033', prefix: '>[', suffix: ']' },
+    disabledStyle: { fg: '#000099', bg: '#0000ff', prefix: '  ' },
+    disabledSelectedStyle: { fg: '#000000', bg: '#000033', prefix: '> ' },
     options: [
       { text: 'Option 1', value: 1 },
       { text: 'Option 2 takes two lines', value: 2 },
-      { text: 'Option 3 is very very long and takes three lines', value: 3 },
+      { text: 'Option 3 is very very long and actually takes FOUR lines', value: 3 },
       { text: 'Option 4', value: 4 },
+      { text: 'Option 5 takes two lines', value: 5 },
     ],
-  });
+  } as SelectOptions<number>);
 
   const s3 = terminal.attachWidget(Box, {
     ...boxOptions,
-    title: '[Select-C]',
+    title: '[S3] multiple selection',
     col: 1,
     line: 13,
-    width: 30,
+    width: 27,
     height: 7,
   })
   .attachWidget<Select<number>>(Select, {
-    selectedIndex: 0,
-    selectedPrefix: '>',
+    multiple: true,
+    baseStyle: { prefix: '[ ] ' },
+    baseFocusedStyle: { prefix: '[ ] ' },
+    selectedStyle: { prefix: '[x] ' },
+    selectedFocusedStyle: { prefix: '[x] ' },
+    disabledStyle: { prefix: '[ ] ' },
+    disabledSelectedStyle: { prefix: '[x] ' },
     options: [
-      { text: 'Option 1 (default)', value: 1 },
+      { text: 'Option 1', value: 1 },
       { text: 'Option 2', value: 2 },
       { text: 'Option 3', value: 3 },
+      { text: 'Option 4', value: 4 },
     ],
-  });
+  } as SelectOptions<number>);
 
   enableInteraction([s1, s2, s3], terminal, canvas);
 }

--- a/examples/widgets/select.ts
+++ b/examples/widgets/select.ts
@@ -84,6 +84,7 @@ function run({ terminal, canvas }: LoadData): void {
   })
   .attachWidget<Select<number>>(Select, {
     selectedIndex: 0,
+    selectedPrefix: '>',
     options: [
       { text: 'Option 1 (default)', value: 1 },
       { text: 'Option 2', value: 2 },

--- a/src/widgets/Select.ts
+++ b/src/widgets/Select.ts
@@ -312,6 +312,42 @@ export class Select<T> extends Widget<SelectOptions<T>> {
   }
 
   /**
+   * Check if the option with the specified index is selected or not
+   *
+   * @param index index of the option to check
+   * @returns `true` if selected, `false` if not. `undefined` if the option is not found
+   */
+  public isIndexSelected(index: number): boolean {
+    const item = this.selectOptions[index];
+
+    return item ? item.selected : undefined;
+  }
+
+  /**
+   * Check if an option is selected or not
+   *
+   * @param option option to check
+   * @returns `true` if selected, `false` if not. `undefined` if the option is not found
+   */
+  public isOptionSelected(option: SelectOption<T>): boolean {
+    const index = this.getIndexFromOption(option);
+
+    return index === SELECT_INDEX_NONE ? undefined : this.selectOptions[index].selected;
+  }
+
+  /**
+   * Check if the option with the specified value is selected or not
+   *
+   * @param value value to check
+   * @returns `true` if selected, `false` if not. `undefined` if the option is not found
+   */
+  public isValueSelected(value: T): boolean {
+    const index = this.getIndexFromValue(value);
+
+    return index === SELECT_INDEX_NONE ? undefined : this.selectOptions[index].selected;
+  }
+
+  /**
    * Select the option with the specified index.
    * This will do nothing if the option is disabled or the index is invalid.
    * If `options.multiple` is `false`, then it will unselect any previously selected option.

--- a/src/widgets/Select.ts
+++ b/src/widgets/Select.ts
@@ -1,12 +1,14 @@
+import { isEmpty } from 'vanilla-type-check/isEmpty';
+
 import { CharStyle, Terminal } from '../Terminal';
 import { Widget, WidgetOptions } from '../Widget';
 import { WidgetContainer } from '../WidgetContainer';
 
-import { coalesce } from '../util/coalesce';
 import { deepAssign } from '../util/deepAssign';
 import { splitText, TokenizerFunction } from '../util/tokenizer';
 
-export const UNSELECTED_INDEX = -1;
+/** Value used for an option index when no option is selected or found */
+export const SELECT_INDEX_NONE = -1;
 
 export interface SelectOption<T> {
   /** Displayed text of the option */
@@ -17,51 +19,78 @@ export interface SelectOption<T> {
   disabled?: boolean;
 }
 
+export interface SelectOptionStyle extends CharStyle {
+  /** Text to add to the option at the beginning */
+  prefix?: string;
+  /** Text to add to the option at the end */
+  suffix?: string;
+}
+
 export interface SelectOptions<T> extends WidgetOptions {
   /** List of options, in order, to display. Editing this value (via `setOptions` will reset the selected one) */
   options: Array<SelectOption<T>>;
   /** If `true`, the first option will be highlighted after the last one, and viceversa */
   loop?: boolean;
-  /** Selected option index by default */
-  selectedIndex?: number;
+  /** When `false`, it will be only one option selected at most */
+  multiple?: boolean;
   /** If `true`, will unselect any selected option if try to select a non-existing one */
   allowUnselect?: boolean;
+
+  /** Character Style for base options */
+  baseStyle?: SelectOptionStyle;
+  /** Character Style for base options when focused */
+  baseFocusedStyle?: SelectOptionStyle;
+  /** Character Style for selected options */
+  selectedStyle?: SelectOptionStyle;
+  /** Character Style for selected options when focused */
+  selectedFocusedStyle?: SelectOptionStyle;
+  /** Character Style for disabled options */
+  disabledStyle?: SelectOptionStyle;
+  /** Character Style for disabled options when selected */
+  disabledSelectedStyle?: SelectOptionStyle;
+
   /**
    * How to split the text (for new lines, etc.)
    * A custom TokenizerFunction can be provided. Leave undefined to use the default one
    */
   tokenizer?: TokenizerFunction;
-  /** Character Style for base options */
-  base?: CharStyle;
-  /** Character Style for selected options */
-  selected?: CharStyle;
-  /** Character Style for disabled options */
-  disabled?: CharStyle;
-  /** Prefix to add to the selected options */
-  selectedPrefix?: string;
-  /** Prefix to add to the non selected options */
-  unselectedPrefix? : string;
+}
+
+type StyleStates = 'baseStyle'
+                 | 'baseFocusedStyle'
+                 | 'selectedStyle'
+                 | 'selectedFocusedStyle'
+                 | 'disabledStyle'
+                 | 'disabledSelectedStyle';
+
+interface InternalOption<T> {
+  /** Copy of the provided option */
+  option: SelectOption<T>;
+  /** Will be true if selected */
+  selected: boolean;
+  /** Preprocessed text to draw (one string per line) */
+  processedText: string[];
+  /** Line where this option should start (accumulated number of lines of the previous options) */
+  startLine: number;
+  /** Line where the next option should start (start + processedText.length) */
+  endLine: number;
 }
 
 /**
- * Display a list of selectable options
+ * Display a list of selectable options.
+ * The focused option is where the cursor is. It can be none or one at most.
+ * Selected options can be none, one or, if the `multiple` option is `true`, more than one at the same time
  */
 export class Select<T> extends Widget<SelectOptions<T>> {
   /** Default options for widget instances */
   public static defaultOptions: SelectOptions<any>; // tslint:disable-line:no-any
 
-  /** Currently selected option index */
-  private selectedIndex: number = UNSELECTED_INDEX;
+  /** Currently active option index */
+  private focusedIndex: number = SELECT_INDEX_NONE;
+  /** Lits of the options used internally */
+  private selectOptions: InternalOption<T>[];
   /** First line to draw (for scrolling) - note: one option can have more than one line */
   private firstLine: number = 0;
-  /** Processed options text */
-  private optionsText: string[][];
-  /** Processed indentation text */
-  private indentation: string;
-  /** Processed selected prefix text  */
-  private selectedPrefix: string;
-  /** Processed unselected prefix text */
-  private unselectedPrefix: string;
 
   constructor(terminal: Terminal, options: SelectOptions<T>, parent?: WidgetContainer) {
     super(
@@ -70,81 +99,204 @@ export class Select<T> extends Widget<SelectOptions<T>> {
       parent,
     );
 
-    let rendered = false;
-    if (this.options.selectedIndex >= 0) {
-      rendered = this.selectIndex(this.options.selectedIndex);
-    }
-    if (!rendered) {
-      this.render();
-    }
+    this.render();
   }
 
   /**
    * Render the widget in the associated terminal
    */
   public render(): void {
-    if (!this.optionsText) {
+    if (!this.selectOptions) {
       return;
     }
 
-    const lastLine = this.options.line + this.options.height;
+    const lastTerminalLine = this.options.line + this.options.height;
     let terminalLine = this.options.line; // line of the terminal to output the text
-    let option = 0; // option index
-    let optionLine = 0; // text line inside the current option
-    let line = 0; // accumulated internal option lines
+    let optionIndex = 0;
 
-    while (line < this.firstLine) {
-      line++;
-      optionLine++;
-      if (optionLine >= this.optionsText[option].length) {
-        option++;
-        optionLine = 0;
+    // skip first hidden lines
+    while (this.selectOptions[optionIndex].endLine <= this.firstLine) {
+      optionIndex++;
+    }
+    let skipLines = this.firstLine - this.selectOptions[optionIndex].startLine;
+
+    // write visible lines
+    while (optionIndex < this.selectOptions.length && terminalLine < lastTerminalLine) {
+      this.terminal.setTextStyle(this.getOptionStyle(optionIndex));
+      const text = this.getOptionText(optionIndex);
+
+      for (const textLine of text) {
+        if (terminalLine >= lastTerminalLine) {
+          break;
+        }
+        if (skipLines > 0) {
+          skipLines--;
+          continue;
+        }
+        this.terminal.setText(textLine, this.options.col, terminalLine);
+        terminalLine++;
       }
+
+      optionIndex++;
     }
 
-    this.terminal.setTextStyle(this.getAspectOptions(option));
-    const col = this.options.col;
-    const indentedCol = col + (this.indentation.length);
-    while (option < this.optionsText.length && terminalLine < lastLine) {
-      if (col !== indentedCol) {
-        if (optionLine > 0) {
-          this.terminal.setText(this.indentation, col, terminalLine);
-        } else if (this.selectedIndex === option) {
-          this.terminal.setText(this.selectedPrefix, col, terminalLine);
-        } else {
-          this.terminal.setText(this.unselectedPrefix, col, terminalLine);
-        }
-      }
-      this.terminal.setText(this.optionsText[option][optionLine], indentedCol, terminalLine);
-      terminalLine++;
-      optionLine++;
-      if (optionLine >= this.optionsText[option].length) {
-        option++;
-        optionLine = 0;
-        if (option < this.optionsText.length) {
-          this.terminal.setTextStyle(this.getAspectOptions(option));
-        }
-      }
-    }
+    // write blank lines if any
+    this.terminal.clear(this.options.col, terminalLine, this.options.width, lastTerminalLine - terminalLine);
   }
 
   /**
-   * Retrieve a reference to the currently selected option.
-   * Even if it's a reference, don't update it directly, but use `setOptions` to allow the widget to apply the changes
+   * Get the provided option from the specified index
    *
-   * @return Object specified in `options.options`.
+   * @param index index of the desired option
+   * @return Reference to a copy of the provided option
    */
-  public getSelectedOption(): SelectOption<T> {
-    return this.options.options[this.selectedIndex];
+  public getOptionFromIndex(index: number): SelectOption<T> {
+    const opt = this.selectOptions[index];
+
+    return opt ? opt.option : undefined;
   }
 
   /**
-   * Retrieve the index of the currently selected option
+   * Get the provided value from the specified index
+   *
+   * @param index index of the desired option
+   * @return Reference to a copy of the provided value
+   */
+  public getValueFromIndex(index: number): T {
+    const opt = this.selectOptions[index];
+
+    return opt ? opt.option.value : undefined;
+  }
+
+  /**
+   * Get the index of the desired option
+   *
+   * @param option option to search
+   * @return Index of the option in the select list or `INDEX_NONE` if not found
+   */
+  public getIndexFromOption(option: SelectOption<T>): number {
+    for (let i = 0; i < this.options.options.length; i++) {
+      if (this.options.options[i] === option) {
+        return i;
+      }
+    }
+
+    return SELECT_INDEX_NONE;
+  }
+
+  /**
+   * Get the index of the desired value
+   *
+   * @param value value to search
+   * @return Index of the option in the select list or `INDEX_NONE` if not found
+   */
+  public getIndexFromValue(value: T): number {
+    for (let i = 0; i < this.selectOptions.length; i++) {
+      if (this.selectOptions[i].option.value === value) {
+        return i;
+      }
+    }
+
+    return SELECT_INDEX_NONE;
+  }
+
+  /**
+   * Retrieve a list of indexes of the selected options.
+   *
+   * @return Indexes of the selected options
+   */
+  public getSelectedIndexes(): number[] {
+    const res: number[] = [];
+
+    this.selectOptions.forEach((option, i) => {
+      if (option.selected) {
+        res.push(i);
+      }
+    });
+
+    return res;
+  }
+
+  /**
+   * Retrieve a list of selected options.
+   * Even if this is a list of references to the given options, refrain of modifying them directly.
+   * Use `setOptions` instead.
+   *
+   * @return List of selected options
+   */
+  public getSelectedOptions(): SelectOption<T>[] {
+    return this.getSelectedIndexes().map((index) => this.selectOptions[index].option);
+  }
+
+  /**
+   * Retrieve a list of selected values.
+   *
+   * @return List of selected values
+   */
+  public getSelectedValues(): T[] {
+    return this.getSelectedIndexes().map((index) => this.selectOptions[index].option.value);
+  }
+
+  /**
+   * Retrieve the index of the focused option
    *
    * @return index of the selected option or `UNSELECTED_INDEX` if no one is selected
    */
-  public getSelectedIndex(): number {
-    return this.selectedIndex;
+  public getFocusedIndex(): number {
+    return this.focusedIndex;
+  }
+
+  /**
+   * Retrieve the focused option
+   *
+   * @return Reference to the given focused option, or `undefined` if nothing is selected
+   */
+  public getFocusedOption(): SelectOption<T> {
+    return this.getOptionFromIndex(this.focusedIndex);
+  }
+
+  /**
+   * Retrieve the value of the focused option
+   *
+   * @return Reference to the given focused option value, or `undefined` if nothing is selected
+   */
+  public getFocusedValue(): T {
+    return this.getValueFromIndex(this.focusedIndex);
+  }
+
+  /**
+   * Get the index of the option at the specified terminal position (absolute)
+   *
+   * @param column column of the terminal
+   * @param line line of the terminal
+   * @return index of the option or `INDEX_NONE` if not found
+   */
+  public getIndexAt(column: number, line: number): number {
+    const maxHeight = this.options.line + this.options.height;
+
+    if (column < this.options.col || column >= this.options.col + this.options.width
+      || line < this.options.line || line >= maxHeight) {
+      return SELECT_INDEX_NONE;
+    }
+
+    let terminalLine = this.options.line;
+    let optionLine = 0;
+    let optionIndex = 0;
+
+    while (optionIndex < this.selectOptions.length && terminalLine < maxHeight) {
+      if (terminalLine === line) {
+        return optionIndex;
+      }
+
+      terminalLine++;
+      optionLine++;
+      if (optionLine >= this.selectOptions[optionIndex].processedText.length) {
+        optionIndex++;
+        optionLine = 0;
+      }
+    }
+
+    return SELECT_INDEX_NONE;
   }
 
   /**
@@ -155,63 +307,107 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    * @return option or `undefined` if not found
    */
   public getOptionAt(column: number, line: number): SelectOption<T> {
-    if (column < this.options.col || column >= this.options.col + this.options.width) {
-      return;
-    }
+    return this.getOptionFromIndex(this.getIndexAt(column, line));
+  }
 
-    let terminalLine = this.options.line;
-    let optionLine = 0;
-    let option = 0;
-
-    while (option < this.optionsText.length) {
-      if (terminalLine === line) {
-        return this.options.options[option];
-      }
-
-      terminalLine++;
-      optionLine++;
-      if (optionLine >= this.optionsText[option].length) {
-        option++;
-        optionLine = 0;
-      }
-    }
-
-    return;
+  /**
+   * Get the value of the option at the specified terminal position (absolute)
+   *
+   * @param column column of the terminal
+   * @param line line of the terminal
+   * @return option value or `undefined` if not found
+   */
+  public getValueAt(column: number, line: number): T {
+    return this.getValueFromIndex(this.getIndexAt(column, line));
   }
 
   /**
    * Select the option with the specified index.
-   * This will do nothing if the option is disabled or the index not found.
+   * This will do nothing if the option is disabled or the index is invalid.
+   * If `options.multiple` is `false`, then it will unselect any previously selected option.
+   * The list won't focus the option and therefore, the scroll won't change.
+   *
+   * @param index New index to set as selected (starting on 0)
+   * @param selected If `true` the option will be set as selected.
+   *                 If `false`, the option will be set as unselected.
+   *                 If `undefined`, the option will be negated (selected -> unselected / unselected -> selected)
+   * @return `true` if the selected option has changed, `false` otherwise
+   */
+  public toggleIndex(index: number, selected?: boolean): boolean {
+    const item = this.selectOptions[index];
+    const newState = selected === undefined ? !item.selected : selected;
+    let change = item.selected !== newState;
+    item.selected = newState;
+
+    if (!this.options.multiple && item.selected) {
+      for (let i = 0; i < this.selectOptions.length; i++) {
+        const unselectedItem = this.selectOptions[i];
+        if (i !== index) {
+          change = change || unselectedItem.selected;
+          unselectedItem.selected = false;
+        }
+      }
+    }
+
+    if (change) {
+      this.render();
+      return true;
+    }
+
+    return true;
+  }
+
+  /**
+   * Select the first option with the specified.
+   * This will do nothing if all the options with that value are disabled
+   *
+   * @param option Value to search the option by
+   * @return `true` if the selected option has changed, `false` otherwise
+   */
+  public selectOption(option: SelectOption<T>): boolean {
+    return this.toggleIndex(this.getIndexFromOption(option));
+  }
+
+  /**
+   * Select the first option with the specified value.
+   * This will do nothing if all the options with that value are disabled
+   *
+   * @param value Value to search the option by
+   * @return `true` if the selected option has changed, `false` otherwise
+   */
+  public selectValue(value: T): boolean {
+    return this.toggleIndex(this.getIndexFromValue(value));
+  }
+
+  /**
+   * Focus the option with the specified index.
+   * This will do nothing if the option is already focused or the index is invalid.
+   * The list will scroll to show the focused option if needed.
    *
    * @param index New index to set as selected (starting on 0)
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public selectIndex(index: number): boolean {
-    const oldIndex = this.selectedIndex;
+  public focusIndex(index: number): boolean {
+    const oldIndex = this.focusedIndex;
+    const selectedOption = this.selectOptions[index];
 
-    if (this.optionsText[index]) {
-      if (!this.options.options[index].disabled && this.selectedIndex !== index) {
-        this.selectedIndex = index;
+    if (selectedOption) {
+      if (!selectedOption.option.disabled && this.focusedIndex !== index) {
+        this.focusedIndex = index;
 
         // manage the scroll to make the selected option appear in the screen
-        let startLine = 0;
-        for (let i = 0; i < index; i++) {
-          startLine += this.optionsText[i].length;
+        if (selectedOption.endLine > this.firstLine + this.options.height) {
+          this.firstLine = selectedOption.endLine - selectedOption.processedText.length + 1;
         }
-        const endLine = startLine + this.optionsText[index].length;
-
-        if (endLine >= this.firstLine + this.options.height) {
-          this.firstLine += endLine - this.firstLine - this.options.height;
-        }
-        if (startLine < this.firstLine) {
-          this.firstLine = startLine;
+        if (selectedOption.startLine < this.firstLine) {
+          this.firstLine = selectedOption.startLine;
         }
       }
-    } else if (this.options.allowUnselect && this.selectedIndex !== UNSELECTED_INDEX) {
-      this.selectedIndex = UNSELECTED_INDEX;
+    } else if (this.options.allowUnselect) {
+      this.focusedIndex = SELECT_INDEX_NONE;
     }
 
-    if (oldIndex !== this.selectedIndex) {
+    if (oldIndex !== this.focusedIndex) {
       this.render();
 
       return true;
@@ -221,59 +417,36 @@ export class Select<T> extends Widget<SelectOptions<T>> {
   }
 
   /**
-   * Select the first option with the specified value.
-   * This will do nothing if all the options with that value are disabled
-   * there's no one with the specified value.
+   * Focus the the specified option
+   * This will do nothing if the option is already focused or not found
+   * The list will scroll to show the focused option if needed.
    *
-   * @param value Value to search the option by
+   * @param option Option to focus
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public selectValue(value: T): boolean {
-    let found = false;
-    const options = this.options.options;
-    for (let i = 0; i < options.length; i++) {
-      if (options[i].value === value) {
-        found = true;
-        const enabled = this.selectIndex(i);
-        if (enabled) {
-          return true;
-        }
-      }
-    }
-
-    return found ? false : this.selectIndex(UNSELECTED_INDEX);
+  public focusOption(option: SelectOption<T>): boolean {
+    return this.focusIndex(this.getIndexFromOption(option));
   }
 
   /**
-   * Select the specified option.
-   * This will do nothing the option is disabled or not found
+   * Focus the option with the specified value
+   * This will do nothing if the option is already focused or not found
+   * The list will scroll to show the focused option if needed.
    *
-   * @param option Explicit option to select
+   * @param value Value to set as selected
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public selectOption(option: SelectOption<T>): boolean {
-    let found = false;
-    const options = this.options.options;
-    for (let i = 0; i < options.length; i++) {
-      if (options[i] === option) {
-        found = true;
-        const enabled = this.selectIndex(i);
-        if (enabled) {
-          return true;
-        }
-      }
-    }
-
-    return found ? false : this.selectIndex(UNSELECTED_INDEX);
+  public focusValue(value: T): boolean {
+    return this.focusIndex(this.getIndexFromValue(value));
   }
 
   /**
-   * Select the previous option to the current one
+   * Focus the previous option to the current one
    *
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public prev(): boolean {
-    return this.moveSelection(-1);
+  public focusPrev(): boolean {
+    return this.moveFocus(-1);
   }
 
   /**
@@ -281,8 +454,8 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    *
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  public next(): boolean {
-    return this.moveSelection(+1);
+  public focusNext(): boolean {
+    return this.moveFocus(+1);
   }
 
   /**
@@ -292,55 +465,41 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    * @param changes Object with only the changed options
    */
   protected updateOptions(changes: SelectOptions<T>): void {
-    function fixString(str: string, length: number): string {
-      if (str === undefined) {
-        ' '.repeat(length);
-      }
-      if (str.length === length) {
-        return str;
-      }
-      return str.substr(0, length) + ' '.repeat(length - str.length);
+    // const updateStyle = (state: StyleStates): void => {
+    //   if (changes[state]) {
+    //     this.options[state] = {
+    //       ...Select.defaultOptions[state],
+    //       ...this.options[state],
+    //       ...changes[state],
+    //     };
+    //   }
+    // };
+
+    if (isEmpty(changes)) {
+      return;
     }
 
-    const dirtyText = coalesce(
-      changes.options,
-      changes.width,
-      changes.selectedPrefix,
-      changes.unselectedPrefix,
-    ) !== undefined;
-    const reDraw = coalesce(
-      changes.col,
-      changes.line,
-      changes.height,
-      changes.base,
-      changes.selected,
-      changes.disabled,
-    ) !== undefined;
-    let drawn = false;
+    // updateStyle('baseStyle');
+    // updateStyle('baseFocusedStyle');
+    // updateStyle('selectedStyle');
+    // updateStyle('selectedFocusedStyle');
+    // updateStyle('disabledStyle');
+    // updateStyle('disabledSelectedStyle');
 
-    if (coalesce(changes.selectedPrefix, changes.unselectedPrefix) !== undefined) {
-      const prefixLength = Math.max(
-        this.options.selectedPrefix ? this.options.selectedPrefix.length : 0,
-        this.options.unselectedPrefix ? this.options.unselectedPrefix.length : 0,
-      );
-      this.indentation = ' '.repeat(prefixLength);
-      this.selectedPrefix = fixString(this.options.selectedPrefix, prefixLength);
-      this.unselectedPrefix = fixString(this.options.unselectedPrefix, prefixLength);
-    }
+    let startLine = 0;
+    this.selectOptions = this.options.options.map((option) => {
+      const processedText = splitText(option.text, this.options.width, this.options.tokenizer);
+      const opt = {
+        startLine,
+        processedText,
+        endLine: startLine + processedText.length,
+        option: { ...option },
+        selected: false,
+      };
+      startLine = opt.endLine;
 
-    if (dirtyText && this.options.options) {
-      if (this.indentation === undefined) {
-        this.indentation = '';
-      }
-      const width = this.options.width - this.indentation.length;
-      this.optionsText = this.options.options.map((option) =>
-        splitText(option.text, width, this.options.tokenizer));
-      drawn = this.selectIndex(this.options.selectedIndex);
-    }
-
-    if (!drawn && (dirtyText || reDraw)) {
-      this.render();
-    }
+      return opt;
+    });
   }
 
   /**
@@ -349,37 +508,37 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    * @param delta how many options to "move" (`-1`: previous one, `+1`: next one)
    * @return `true` if the selected option has changed, `false` otherwise
    */
-  private moveSelection(delta: number): boolean {
-    const options = this.options.options;
-    let newIndex = this.selectedIndex;
-    let tries = options.length; // to prevent infinite loop in case there's no available option
+  private moveFocus(delta: number): boolean {
+    const selectOptions = this.selectOptions;
+    let newIndex = this.focusedIndex;
+    let tries = selectOptions.length; // to prevent infinite loop in case there's no available option
 
     do {
       newIndex = newIndex + delta;
 
       if (newIndex < 0) {
         if (this.options.loop) {
-          newIndex = options.length - 1;
+          newIndex = selectOptions.length - 1;
         } else {
           newIndex = 0;
           break;
         }
-      } else if (newIndex >= options.length) {
+      } else if (newIndex >= selectOptions.length) {
         if (this.options.loop) {
           newIndex = 0;
         } else {
-          newIndex = options.length - 1;
+          newIndex = selectOptions.length - 1;
           break;
         }
       }
 
-      if (!options[newIndex].disabled) {
+      if (!selectOptions[newIndex].option.disabled) {
         break;
       }
       tries--;
-    } while (newIndex !== this.selectedIndex && tries > 0);
+    } while (newIndex !== this.focusedIndex && tries > 0);
 
-    return tries > 0 ? this.selectIndex(newIndex) : false;
+    return tries > 0 ? this.focusIndex(newIndex) : false;
   }
 
   /**
@@ -387,16 +546,64 @@ export class Select<T> extends Widget<SelectOptions<T>> {
    *
    * @return `CharStyle` object corresponding to the specified option index
    */
-  private getAspectOptions(optionIndex: number): CharStyle {
-    if (optionIndex === this.selectedIndex) {
-      return this.options.selected;
+  private getOptionStyle(optionIndex: number): SelectOptionStyle {
+    const item = this.selectOptions[optionIndex];
+    const status = ((isSelected, isFocused, isDisabled): StyleStates => {
+      if (isSelected) {
+        if (isDisabled) {
+          return 'disabledSelectedStyle';
+        }
+        if (isFocused) {
+          return 'selectedFocusedStyle';
+        }
+        return 'selectedStyle';
+      }
+
+      if (isDisabled) {
+        return 'disabledStyle';
+      }
+
+      if (isFocused) {
+        return 'baseFocusedStyle';
+      }
+
+      return 'baseStyle';
+    })(item.selected, this.focusedIndex === optionIndex, item.option.disabled);
+
+    return this.options[status];
+  }
+
+  /**
+   * Get the text of an option based in its state
+   *
+   * @param optionIndex
+   */
+  private getOptionText(optionIndex: number): string[] {
+    const item = this.selectOptions[optionIndex];
+    const style = this.getOptionStyle(optionIndex);
+    let width = this.options.width;
+
+    if (style.prefix) {
+      width -= style.prefix.length;
+    }
+    if (style.suffix) {
+      width -= style.suffix.length;
     }
 
-    if (this.options.options[optionIndex] && this.options.options[optionIndex].disabled) {
-      return this.options.disabled;
+    const splittedText = splitText(item.option.text, width, this.options.tokenizer);
+    if (!style.prefix && !style.suffix) {
+      return splittedText;
     }
 
-    return this.options.base;
+    const prefixIndentation = style.prefix ? ' '.repeat(style.prefix.length) : '';
+    const suffixIndentation = style.suffix ? ' '.repeat(style.suffix.length) : '';
+
+    return splittedText.map((line, i) => {
+      const prefix = !style.prefix || i !== 0 ? prefixIndentation : style.prefix;
+      const suffix = !style.suffix || i !== splittedText.length - 1 ? suffixIndentation : style.suffix;
+
+      return prefix + line + suffix;
+    });
   }
 }
 
@@ -406,11 +613,12 @@ export class Select<T> extends Widget<SelectOptions<T>> {
 Select.defaultOptions = {
   options: undefined,
   loop: true,
+  multiple: false,
   allowUnselect: true,
-  base: { fg: '#00ff00', bg: '#000000' },
-  selected: { fg: '#00ff00', bg: '#009900' },
-  disabled: { fg: '#009900', bg: '#000000' },
-  selectedIndex: UNSELECTED_INDEX,
-  selectedPrefix: '',
-  unselectedPrefix: '',
+  baseStyle: { fg: '#00ff00', bg: '#000000', prefix: ' ' },
+  baseFocusedStyle: { fg: '#ffffff', bg: '#000000', prefix: ' ' },
+  selectedStyle: { fg: '#00ff00', bg: '#000000', prefix: '*' },
+  selectedFocusedStyle: { fg: '#ffffff', bg: '#000000', prefix: '*' },
+  disabledStyle: { fg: '#009900', bg: '#000000', prefix: ' ' },
+  disabledSelectedStyle: { fg: '#009900', bg: '#000000', prefix: '*' },
 };

--- a/src/widgets/Select.ts
+++ b/src/widgets/Select.ts
@@ -279,20 +279,10 @@ export class Select<T> extends Widget<SelectOptions<T>> {
       return SELECT_INDEX_NONE;
     }
 
-    let terminalLine = this.options.line;
-    let optionLine = 0;
-    let optionIndex = 0;
-
-    while (optionIndex < this.selectOptions.length && terminalLine < maxHeight) {
-      if (terminalLine === line) {
-        return optionIndex;
-      }
-
-      terminalLine++;
-      optionLine++;
-      if (optionLine >= this.selectOptions[optionIndex].processedText.length) {
-        optionIndex++;
-        optionLine = 0;
+    const realLine = this.firstLine + line - this.options.line;
+    for (let i = 0; i < this.selectOptions.length; i++) {
+      if (this.selectOptions[i].endLine > realLine) {
+        return i;
       }
     }
 


### PR DESCRIPTION
Improvements for the Select widget:

Added new methods:
- `Select.getIndexFrom*`
- `Select.get*FromIndex`
- `Select.getSelected*s`
- `Select.getFocused*`
- `Select.get*At`
- `Select.is*Selected`
- `Select.focus*`

Changed method:
- `Select.select` is now `Select.toggle*`
- `Select.prev` is now `Select.focusPrev`
- `Select.next` is now `Select.focusNext`

(being `*` = `Index` | `Option` | `Value`)

`Select.options` now accept more detailed style descriptions for each style, including `prefix` and `suffix` as new style properties:
- `baseStyle`
- `baseFocusedStyle`
- `selectedStyle`
- `selectedFocusedStyle`
- `disabledStyle`
- `disabledSelectedStyle`